### PR TITLE
Feat: 관리자 로그인 페이지 및 JWT 인증 구현

### DIFF
--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/config/DataInitializer.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/config/DataInitializer.java
@@ -28,6 +28,7 @@ public class DataInitializer implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) {
+        if (referenceTagRepository.count() > 0) return;
         Tags tags = saveTags();
         initEngVocaQuizContents(tags);
         initBibleQuizContents(tags);

--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/controller/AdminAuthController.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/controller/AdminAuthController.java
@@ -1,0 +1,39 @@
+package JesusDeciples.RankingQuiz.api.controller;
+
+import JesusDeciples.RankingQuiz.api.enums.Authority;
+import JesusDeciples.RankingQuiz.api.jwt.JWTProducer;
+import JesusDeciples.RankingQuiz.api.oauth.AuthTokens;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Date;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth/admin")
+@CrossOrigin(origins = {"http://localhost:8081", "https://rankingquiz.rivercastleworks.site"})
+public class AdminAuthController {
+
+    private static final String ADMIN_ID = "admin";
+    private static final String ADMIN_PASSWORD = "admin";
+    private static final long EXPIRES_IN_MS = 1000L * 60 * 60 * 24; // 24시간
+
+    private final JWTProducer jwtProducer;
+
+    @PostMapping
+    public ResponseEntity<?> adminLogin(@RequestBody Map<String, String> body) {
+        String id = body.get("id");
+        String password = body.get("password");
+
+        if (!ADMIN_ID.equals(id) || !ADMIN_PASSWORD.equals(password)) {
+            return ResponseEntity.status(401).body("아이디 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        Date expiredAt = new Date(System.currentTimeMillis() + EXPIRES_IN_MS);
+        String accessToken = jwtProducer.produceJwt(ADMIN_ID, Authority.ROLE_ADMIN, expiredAt);
+
+        return ResponseEntity.ok(AuthTokens.of(accessToken, "Bearer", EXPIRES_IN_MS));
+    }
+}

--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/jwt/JWTProducer.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/jwt/JWTProducer.java
@@ -6,6 +6,11 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.beans.factory.annotation.Value;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -13,10 +18,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
 
 @Component
 public class JWTProducer {
@@ -29,7 +30,7 @@ public class JWTProducer {
                 .setSubject(subject)
                 .claim("auth", authority)
                 .setExpiration(expiredAt)
-                .signWith(SignatureAlgorithm.HS256, key)
+                .signWith(SignatureAlgorithm.HS256, key.getBytes(StandardCharsets.UTF_8))
                 .compact();
     }
 
@@ -47,7 +48,7 @@ public class JWTProducer {
     private Claims parseClaims(String accessToken) {
         try {
             return Jwts.parserBuilder()
-                    .setSigningKey(key)
+                    .setSigningKey(key.getBytes(StandardCharsets.UTF_8))
                     .build()
                     .parseClaimsJws(accessToken)
                     .getBody();

--- a/RankingQuizFront/src/main/java/rankingquizfront/admin/controller/AdminPageController.java
+++ b/RankingQuizFront/src/main/java/rankingquizfront/admin/controller/AdminPageController.java
@@ -12,4 +12,9 @@ public class AdminPageController {
     public String admin() {
         return "admin/admin";
     }
+
+    @GetMapping("/login")
+    public String adminLogin() {
+        return "admin/admin-login";
+    }
 }

--- a/RankingQuizFront/src/main/resources/static/js/admin-login.js
+++ b/RankingQuizFront/src/main/resources/static/js/admin-login.js
@@ -1,0 +1,45 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // 이미 로그인된 경우 admin 페이지로 이동
+  if (sessionStorage.getItem('adminToken')) {
+    window.location.href = '/admin';
+    return;
+  }
+
+  document.getElementById('loginBtn').addEventListener('click', handleLogin);
+  document.getElementById('adminPw').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') handleLogin();
+  });
+});
+
+async function handleLogin() {
+  const id = document.getElementById('adminId').value.trim();
+  const pw = document.getElementById('adminPw').value;
+  const errorEl = document.getElementById('loginError');
+  const loginBtn = document.getElementById('loginBtn');
+
+  errorEl.classList.add('hidden');
+  loginBtn.disabled = true;
+  loginBtn.textContent = '로그인 중...';
+
+  try {
+    const res = await fetch(`${protocol}${BACKEND_BASE_URL}/auth/admin`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, password: pw })
+    });
+
+    if (!res.ok) {
+      errorEl.classList.remove('hidden');
+      return;
+    }
+
+    const data = await res.json();
+    sessionStorage.setItem('adminToken', data.accessToken);
+    window.location.href = '/admin';
+  } catch (e) {
+    errorEl.classList.remove('hidden');
+  } finally {
+    loginBtn.disabled = false;
+    loginBtn.textContent = '로그인';
+  }
+}

--- a/RankingQuizFront/src/main/resources/static/js/admin.js
+++ b/RankingQuizFront/src/main/resources/static/js/admin.js
@@ -1,19 +1,11 @@
 // =============================================
 // 인증 확인 및 초기화
 // =============================================
-const accessToken = sessionStorage.getItem('accessToken');
+const accessToken = sessionStorage.getItem('adminToken');
 
 document.addEventListener('DOMContentLoaded', () => {
   if (!accessToken) {
-    document.getElementById('loginRequired').classList.remove('hidden');
-    document.getElementById('adminLoginBtn').addEventListener('click', () => {
-      const kakaoAuthUrl =
-        `https://kauth.kakao.com/oauth/authorize` +
-        `?client_id=41ad8e26ac1e92bfcac84f788d229cef` +
-        `&redirect_uri=${protocol}${FRONTEND_BASE_URL}/login-wait` +
-        `&response_type=code`;
-      window.location.href = kakaoAuthUrl;
-    });
+    window.location.href = '/admin/login';
     return;
   }
 

--- a/RankingQuizFront/src/main/resources/templates/admin/admin-login.html
+++ b/RankingQuizFront/src/main/resources/templates/admin/admin-login.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+
+<head th:replace="~{fragments/head :: head('RankingQuiz 관리자 로그인', @{/css/admin.css})}"></head>
+
+<body class="font-display min-h-screen bg-surface-base text-white overflow-x-hidden">
+
+  <div class="fixed inset-0 bg-grid pointer-events-none"></div>
+  <div class="fixed top-[-20%] left-[-10%] w-[500px] h-[500px] bg-neon-blue opacity-[0.06] rounded-full blur-[100px] pointer-events-none"></div>
+  <div class="fixed bottom-[-20%] right-[-10%] w-[500px] h-[500px] bg-neon-purple opacity-[0.06] rounded-full blur-[100px] pointer-events-none"></div>
+
+  <div class="relative z-10 flex flex-col min-h-screen max-w-lg mx-auto px-5 pb-10">
+
+    <header class="pt-10 pb-6 flex items-center justify-between">
+      <div>
+        <p class="text-white/40 text-xs tracking-widest uppercase mb-1">Admin Panel</p>
+        <h1 class="brand-font text-3xl leading-none">
+          <span class="text-white">Ranking</span><span class="text-neon-blue neon-text">Quiz</span>
+          <span class="text-white/60 text-xl ml-2">관리자 로그인</span>
+        </h1>
+      </div>
+      <a href="/" class="text-white/40 hover:text-white/70 text-sm transition-colors">← 홈</a>
+    </header>
+
+    <div class="card-glass rounded-3xl p-8">
+      <p class="text-4xl mb-4 text-center">🔒</p>
+      <p class="text-white/60 text-sm mb-6 text-center">관리자 계정으로 로그인하세요</p>
+      <div class="space-y-3">
+        <input id="adminId" type="text" placeholder="아이디" autocomplete="username"
+          class="neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-3 text-white placeholder-white/25 text-sm" />
+        <input id="adminPw" type="password" placeholder="비밀번호" autocomplete="current-password"
+          class="neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-3 text-white placeholder-white/25 text-sm" />
+        <p id="loginError" class="hidden text-red-400 text-xs text-center pt-1">아이디 또는 비밀번호가 올바르지 않습니다.</p>
+        <button id="loginBtn"
+          class="btn-glow-blue w-full bg-gradient-to-br from-neon-blue to-neon-blue-dark text-surface-base font-bold rounded-2xl py-3 text-sm tracking-wide mt-2">
+          로그인
+        </button>
+      </div>
+    </div>
+
+    <div th:replace="~{fragments/footer :: footer}"></div>
+  </div>
+
+  <script th:src="@{/js/config.js}"></script>
+  <script th:src="@{/js/admin-login.js}"></script>
+
+</body>
+</html>

--- a/RankingQuizFront/src/main/resources/templates/admin/admin.html
+++ b/RankingQuizFront/src/main/resources/templates/admin/admin.html
@@ -24,16 +24,6 @@
       <a href="/" class="text-white/40 hover:text-white/70 text-sm transition-colors">← 홈</a>
     </header>
 
-    <!-- 로그인 안내 (미로그인 시) -->
-    <div id="loginRequired" class="hidden card-glass rounded-3xl p-8 text-center">
-      <p class="text-4xl mb-4">🔒</p>
-      <p class="text-white/60 text-sm mb-5">관리자 로그인이 필요합니다</p>
-      <button id="adminLoginBtn"
-        class="btn-glow-blue bg-gradient-to-br from-neon-blue to-neon-blue-dark text-surface-base font-bold rounded-2xl px-8 py-3 text-sm tracking-wide">
-        카카오 로그인
-      </button>
-    </div>
-
     <!-- 탭 네비게이션 -->
     <div id="adminContent" class="hidden">
       <div class="flex gap-2 mb-6">
@@ -221,7 +211,6 @@
     <div th:replace="~{fragments/footer :: footer}"></div>
   </div>
 
-  <script th:src="@{/js/kakao-login.js}"></script>
   <script th:src="@{/js/admin.js}"></script>
 
 </body>


### PR DESCRIPTION
## Summary
- 관리자 전용 로그인 페이지(`/admin/login`) 신규 생성 — id/pw 입력 후 JWT 발급받아 `/admin`으로 이동
- 백엔드 `POST /api/auth/admin` 엔드포인트 추가 (admin/admin 검증 → ROLE_ADMIN JWT 발급)
- JWT 서명·파싱 시 key를 base64가 아닌 raw bytes로 처리하도록 수정 (DecodingException 해결)
- DataInitializer 중복 삽입 방지 (서버 재시작 시 데이터 중복 등록 버그 수정)

## Test plan
- [ ] `/admin/login` 접속 확인
- [ ] 잘못된 id/pw 입력 시 에러 메시지 표시 확인
- [ ] admin/admin 로그인 성공 후 `/admin` 리다이렉트 확인
- [ ] `/admin` 직접 접속 시 `/admin/login`으로 리다이렉트 확인
- [ ] 관리자 JWT로 퀴즈 상태 조회/변경 API 정상 동작 확인
- [x] 서버 재시작 후 퀴즈 초기 데이터 중복 삽입 없음 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)