### PR TITLE
feat: [admin] 가변 선택지 퀴즈 대량 임포트 기능 추가

### DIFF
--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/controller/QuizContentController.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/controller/QuizContentController.java
@@ -1,9 +1,12 @@
 package JesusDeciples.RankingQuiz.api.controller;
 
 import JesusDeciples.RankingQuiz.api.dto.request.QuizContentCreateDto;
+import JesusDeciples.RankingQuiz.api.dto.response.BulkImportResultDto;
+import JesusDeciples.RankingQuiz.api.enums.QuizCategory;
 import JesusDeciples.RankingQuiz.api.dto.response.QuizContentReviewDto;
 import JesusDeciples.RankingQuiz.api.facade.QuizContentCreateFacade;
 import JesusDeciples.RankingQuiz.api.facade.QuizContentReadFacade;
+import JesusDeciples.RankingQuiz.api.service.BulkImportService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,12 +24,26 @@ import java.util.List;
 public class QuizContentController {
     private final QuizContentCreateFacade quizContentCreateFacade;
     private final QuizContentReadFacade readFacade;
+    private final BulkImportService bulkImportService;
     @PostMapping
     @Operation(summary = "QuizContent 등록",
             description = "주어진 QuizContentCreateDto 배열을 사용하여 퀴즈 콘텐츠를 등록합니다.")
     public void addQuizContent(@RequestBody QuizContentCreateDto[] quizContentCreateDtos) {
         for (QuizContentCreateDto quizContentCreateDto : quizContentCreateDtos)
             quizContentCreateFacade.createQuizContent(quizContentCreateDto);
+    }
+
+    @PostMapping("/bulk-import")
+    @Operation(summary = "QuizContent 대량 등록",
+            description = "탭 구분 텍스트(문제\\t정답\\t선택지JSON)와 카테고리 쿼리 파라미터를 받아 퀴즈 문항을 일괄 등록합니다. 오류 발생 시 전체 취소됩니다.")
+    public ResponseEntity<BulkImportResultDto> bulkImportQuizContent(
+            @RequestParam QuizCategory category,
+            @RequestBody String rawText) {
+        BulkImportResultDto result = bulkImportService.importFromTsv(rawText, category);
+        if (!result.isSuccess()) {
+            return ResponseEntity.badRequest().body(result);
+        }
+        return ResponseEntity.ok(result);
     }
 
     @GetMapping("/review-content/{quizContentId}")

--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/BulkImportService.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/BulkImportService.java
@@ -1,0 +1,108 @@
+package JesusDeciples.RankingQuiz.api.service;
+
+import JesusDeciples.RankingQuiz.api.dto.QuizType;
+import JesusDeciples.RankingQuiz.api.dto.request.QuizContentCreateDto;
+import JesusDeciples.RankingQuiz.api.dto.response.BulkImportResultDto;
+import JesusDeciples.RankingQuiz.api.dto.response.BulkImportRowErrorDto;
+import JesusDeciples.RankingQuiz.api.enums.QuizCategory;
+import JesusDeciples.RankingQuiz.api.facade.QuizContentCreateFacade;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BulkImportService {
+
+    private final QuizContentCreateFacade quizContentCreateFacade;
+    private final ObjectMapper objectMapper;
+
+    public BulkImportResultDto importFromTsv(String rawText, QuizCategory category) {
+        if (rawText == null || rawText.isEmpty()) {
+            return new BulkImportResultDto(false, 0,
+                    List.of(new BulkImportRowErrorDto(0, "입력 데이터가 비어 있습니다.")));
+        }
+
+        String[] lines = rawText.split("\r?\n");
+        List<BulkImportRowErrorDto> errors = new ArrayList<>();
+        List<QuizContentCreateDto> validDtos = new ArrayList<>();
+
+        for (int i = 0; i < lines.length; i++) {
+            int rowNumber = i + 1;
+            String line = lines[i];
+
+            if (line.trim().isEmpty()) continue;
+
+            String[] columns = line.split("\t", -1);
+            if (columns.length != 3) {
+                errors.add(new BulkImportRowErrorDto(rowNumber,
+                        "컬럼 수가 올바르지 않습니다. 탭으로 구분된 3개의 컬럼(문제, 정답, 선택지)이 필요합니다. (실제: " + columns.length + "개)"));
+                continue;
+            }
+
+            String question = columns[0].trim();
+            String answer = columns[1].trim();
+            String choicesRaw = columns[2].trim();
+
+            if (question.isEmpty()) {
+                errors.add(new BulkImportRowErrorDto(rowNumber, "문제 내용이 비어 있습니다."));
+                continue;
+            }
+            if (answer.isEmpty()) {
+                errors.add(new BulkImportRowErrorDto(rowNumber, "정답이 비어 있습니다."));
+                continue;
+            }
+
+            List<String> choices;
+            try {
+                choices = objectMapper.readValue(choicesRaw, new TypeReference<List<String>>() {});
+            } catch (Exception e) {
+                errors.add(new BulkImportRowErrorDto(rowNumber,
+                        "JSON 형식이 올바르지 않습니다 (따옴표 및 대괄호 확인 요망): " + e.getMessage()));
+                continue;
+            }
+
+            if (choices.size() < 2) {
+                errors.add(new BulkImportRowErrorDto(rowNumber,
+                        "선택지는 최소 2개 이상이어야 합니다. (현재: " + choices.size() + "개)"));
+                continue;
+            }
+
+            if (choices.size() % 2 != 0) {
+                errors.add(new BulkImportRowErrorDto(rowNumber,
+                        "선택지 개수는 짝수여야 합니다. (현재: " + choices.size() + "개)"));
+                continue;
+            }
+
+            if (!choices.contains(answer)) {
+                errors.add(new BulkImportRowErrorDto(rowNumber,
+                        "정답이 선택지 목록에 존재하지 않습니다. 정답: '" + answer + "'"));
+                continue;
+            }
+
+            QuizContentCreateDto dto = new QuizContentCreateDto();
+            dto.setStatement(question);
+            dto.setAnswer(answer);
+            dto.setQuizType(QuizType.MULTIPLE_CHOICE);
+            dto.setCategory(category);
+            dto.setMultipleOptions(choices);
+            dto.setTags(Collections.emptyList());
+            validDtos.add(dto);
+        }
+
+        if (!errors.isEmpty()) {
+            return new BulkImportResultDto(false, 0, errors);
+        }
+
+        for (QuizContentCreateDto dto : validDtos) {
+            quizContentCreateFacade.createQuizContent(dto);
+        }
+
+        return new BulkImportResultDto(true, validDtos.size(), Collections.emptyList());
+    }
+}

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/response/BulkImportResultDto.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/response/BulkImportResultDto.java
@@ -1,0 +1,14 @@
+package JesusDeciples.RankingQuiz.api.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class BulkImportResultDto {
+    private final boolean success;
+    private final int savedCount;
+    private final List<BulkImportRowErrorDto> errors;
+}

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/response/BulkImportRowErrorDto.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/response/BulkImportRowErrorDto.java
@@ -1,0 +1,11 @@
+package JesusDeciples.RankingQuiz.api.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BulkImportRowErrorDto {
+    private final int rowNumber;
+    private final String message;
+}

--- a/RankingQuizFront/src/main/resources/static/js/admin.js
+++ b/RankingQuizFront/src/main/resources/static/js/admin.js
@@ -16,6 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
   loadQuizStatus();
   loadSessionCounts();
   setInterval(loadSessionCounts, 15000);
+  document.getElementById('tab-bulk').addEventListener('click', () => switchTab('bulk'));
 });
 
 // =============================================
@@ -29,7 +30,7 @@ function initTabs() {
 }
 
 function switchTab(name) {
-  ['home', 'register'].forEach(t => {
+  ['home', 'register', 'bulk'].forEach(t => {
     document.getElementById(`tab-${t}`).classList.toggle('active', t === name);
     document.getElementById(`panel-${t}`).classList.toggle('hidden', t !== name);
   });
@@ -238,6 +239,73 @@ function showRegisterResult(message, success) {
   el.className = `text-center text-sm py-3 rounded-2xl ${success ? 'success' : 'error'}`;
   el.classList.remove('hidden');
   setTimeout(() => el.classList.add('hidden'), 3000);
+}
+
+// =============================================
+// 대량 등록
+// =============================================
+async function submitBulkImport() {
+  const rawText = document.getElementById('bulkImportText').value;
+  if (!rawText.trim()) {
+    showBulkResult([{ rowNumber: 0, message: '데이터를 입력해주세요.' }], false);
+    return;
+  }
+
+  const btn = document.getElementById('bulkSubmitBtn');
+  btn.disabled = true;
+  btn.textContent = '등록 중...';
+
+  try {
+    const category = document.getElementById('bulkCategory').value;
+  const res = await fetch(`${protocol}${BACKEND_BASE_URL}/quiz-content/bulk-import?category=${category}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/plain;charset=UTF-8',
+        Authorization: `Bearer ${accessToken}`
+      },
+      body: rawText
+    });
+
+    const data = await res.json();
+
+    if (!res.ok || !data.success) {
+      showBulkResult(data.errors, false);
+    } else {
+      showBulkResult(null, true, data.savedCount);
+      document.getElementById('bulkImportText').value = '';
+    }
+  } catch (e) {
+    showBulkResult([{ rowNumber: 0, message: '서버 오류: ' + e.message }], false);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = '대량 등록하기';
+  }
+}
+
+function showBulkResult(errors, success, savedCount) {
+  const el = document.getElementById('bulkResult');
+  el.innerHTML = '';
+  el.classList.remove('hidden');
+
+  if (success) {
+    const msg = document.createElement('div');
+    msg.className = 'text-center text-sm py-3 rounded-2xl success';
+    msg.textContent = `✅ ${savedCount}개의 문제가 성공적으로 등록되었습니다!`;
+    el.appendChild(msg);
+    return;
+  }
+
+  const header = document.createElement('div');
+  header.className = 'text-center text-sm py-3 rounded-2xl error';
+  header.textContent = `❌ 등록 실패 — ${errors.length}개의 오류가 발생했습니다. 수정 후 다시 시도하세요.`;
+  el.appendChild(header);
+
+  errors.forEach(err => {
+    const item = document.createElement('div');
+    item.className = 'bg-white/5 border border-red-500/30 rounded-xl px-4 py-2 text-xs text-red-300';
+    item.textContent = err.rowNumber > 0 ? `${err.rowNumber}번째 줄: ${err.message}` : err.message;
+    el.appendChild(item);
+  });
 }
 
 function resetForm() {

--- a/RankingQuizFront/src/main/resources/templates/admin/admin.html
+++ b/RankingQuizFront/src/main/resources/templates/admin/admin.html
@@ -35,6 +35,10 @@
           class="admin-tab flex-1 py-3 rounded-2xl text-sm font-bold tracking-wide transition-all duration-200">
           ✏️ 문제 등록
         </button>
+        <button id="tab-bulk"
+          class="admin-tab flex-1 py-3 rounded-2xl text-sm font-bold tracking-wide transition-all duration-200">
+          📋 대량 등록
+        </button>
       </div>
 
       <!-- ===== 탭 1: 퀴즈 현황 ===== -->
@@ -209,6 +213,58 @@
           <div id="registerResult" class="hidden text-center text-sm py-3 rounded-2xl"></div>
         </div>
       </div>
+      <!-- ===== 탭 3: 대량 등록 ===== -->
+      <div id="panel-bulk" class="hidden">
+
+        <p class="text-white/40 text-xs tracking-wider uppercase mb-4">퀴즈 대량 등록</p>
+
+        <div class="card-glass rounded-3xl p-6 space-y-5">
+
+          <!-- 카테고리 선택 -->
+          <div>
+            <label class="field-label" for="bulkCategory">카테고리</label>
+            <select
+              id="bulkCategory"
+              class="neon-border w-full bg-surface-base border border-white/10 rounded-2xl px-5 py-4 text-white text-sm mt-2 transition-all duration-200 cursor-pointer"
+            >
+              <option value="ENG_VOCA">📖 단어 퀴즈 (ENG_VOCA)</option>
+              <option value="BIBLE">✝️ 성경 퀴즈 (BIBLE)</option>
+            </select>
+          </div>
+
+          <!-- 입력 형식 안내 -->
+          <div class="bg-white/5 border border-white/10 rounded-2xl p-4 space-y-2">
+            <p class="text-white/60 text-xs font-bold tracking-wide uppercase mb-2">입력 형식 안내</p>
+            <p class="text-white/50 text-xs leading-relaxed">각 행: <span class="text-neon-blue font-mono">문제 [탭] 정답 [탭] 선택지JSON</span></p>
+            <p class="text-white/50 text-xs leading-relaxed">선택지: <span class="text-white/70 font-mono">["보기1", "보기2", "보기3", "보기4"]</span> (짝수 개수)</p>
+            <p class="text-white/40 text-xs leading-relaxed mt-1">예) <span class="font-mono">사과는 영어로?	apple	["apple", "banana", "cherry", "grape"]</span></p>
+          </div>
+
+          <!-- 텍스트 입력 영역 -->
+          <div>
+            <label class="field-label" for="bulkImportText">데이터 붙여넣기</label>
+            <textarea
+              id="bulkImportText"
+              rows="10"
+              placeholder="엑셀에서 복사한 데이터를 여기에 붙여넣으세요."
+              class="neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-4 text-white placeholder-white/25 text-xs font-mono resize-y mt-2 transition-all duration-200"
+            ></textarea>
+          </div>
+
+          <!-- 등록 버튼 -->
+          <button
+            id="bulkSubmitBtn"
+            onclick="submitBulkImport()"
+            class="btn-glow-blue w-full bg-gradient-to-br from-neon-blue to-neon-blue-dark text-surface-base font-bold rounded-2xl py-4 text-sm tracking-wide"
+          >
+            대량 등록하기
+          </button>
+
+          <!-- 결과 영역 -->
+          <div id="bulkResult" class="hidden space-y-2"></div>
+        </div>
+      </div>
+
     </div>
 
     <!-- Footer -->


### PR DESCRIPTION
탭 구분 텍스트(문제\t정답\t선택지JSON)를 붙여넣어 다수의 객관식
문제를 일괄 등록할 수 있는 관리자 기능을 구현한다.
카테고리는 UI 드롭다운으로 선택하며, 행별 파싱 오류 발생 시
전체 트랜잭션을 롤백하고 줄 번호와 원인을 응답한다.