### PR TITLE
fix: [Quiz] 우승자 선정 로직 수정 - 정답자 중 최단 응답 시간 기준으로 변경

### DIFF
--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/quizDataCenter/bible/BibleQuizDataCenter.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/quizDataCenter/bible/BibleQuizDataCenter.java
@@ -17,6 +17,8 @@ import lombok.Setter;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -76,12 +78,22 @@ public class BibleQuizDataCenter extends QuizDataCenter {
     public void score() {
         clearWinnerName();
         clearResults();
+        List<String> winners = new ArrayList<>();
+        LocalDateTime fastest = LocalDateTime.MAX;
         for (AnswerDto answerDto : answerQueue) {
             QuizResultDto resultDto = quizScoreFacade.score(presentQuiz.getId(), answerDto);
-            if (winnerName == null && resultDto.isCorrect()) {
-                winnerName = resultDto.getUserName();
-            }
             results.put(answerDto.getSessionId(), resultDto);
+            LocalDateTime writtenAt = resultDto.getWrittenAt();
+            if (resultDto.isCorrect()) {
+                if (writtenAt.isBefore(fastest)) {
+                    winners.clear();
+                    fastest = writtenAt;
+                    winners.add(resultDto.getUserName());
+                } else if (fastest.equals(writtenAt)) {
+                    winners.add(resultDto.getUserName());
+                }
+            }
+            winnerName = winners.isEmpty() ? null : String.join(", ", winners);
         }
         clearAnswers();
     }

--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/webSocket/messageHandler/WebSocketQuizHandler.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/webSocket/messageHandler/WebSocketQuizHandler.java
@@ -171,7 +171,9 @@ public class WebSocketQuizHandler implements WebSocketHandler {
             if (session == null || !session.isOpen()) continue;
 
             if (sessionIdsOfParticipants.contains(sessionId)) {
-                session.sendMessage(textMessageFactory.produceTextMessage(results.get(sessionId)));
+                QuizResultDto resultDto = results.get(sessionId);
+                resultDto.setWinnerName(winnerName);
+                session.sendMessage(textMessageFactory.produceTextMessage(resultDto));
                 session.sendMessage(winnerAnnouncementMessage);
             } else {
                 GuideMessage notParticipated = new GuideMessage(

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/response/QuizResultDto.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/response/QuizResultDto.java
@@ -16,6 +16,7 @@ public class QuizResultDto {
     private String statement;
     private LocalDateTime writtenAt;
     private String userName;
+    private String winnerName;
 
     public QuizResultDto(boolean isCorrect) {
         this.isCorrect = isCorrect;

--- a/RankingQuizFront/src/main/resources/static/js/quiz/quiz-result-func.js
+++ b/RankingQuizFront/src/main/resources/static/js/quiz/quiz-result-func.js
@@ -18,9 +18,11 @@ function quizResultUpdate(quizResultObject) {
     myAnswerEl.textContent   = '내 답변: ' + (quizResultObject.myAnswer ?? '미제출 😭');
 
     if (winnerNameEl) {
-        winnerNameEl.textContent = quizResultObject.userName
-            ? '🏆 ' + quizResultObject.userName
-            : '';
+        if (quizResultObject.winnerName) {
+            winnerNameEl.textContent = '🏆 ' + quizResultObject.winnerName;
+        } else {
+            winnerNameEl.textContent = '정답자가 없습니다';
+        }
     }
 }
 


### PR DESCRIPTION
- BibleQuizDataCenter.score(): 큐 순서 기반 → writtenAt 타임스탬프 기반으로 수정 (VocaQuizDataCenter와 동일한 알고리즘 적용, 동점자 전원 포함)
- QuizResultDto에 winnerName 필드 추가
- WebSocketQuizHandler: QuizResultDto 전송 시 winnerName 주입
- quiz-result-func.js: userName 대신 winnerName 읽도록 수정, 정답자 0명 시 "정답자가 없습니다" 출력