### PR TITLE
feat: 관리자 퀴즈 관리 탭 추가

### DIFF
--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/controller/QuizContentController.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/controller/QuizContentController.java
@@ -7,10 +7,15 @@ import JesusDeciples.RankingQuiz.api.dto.response.QuizContentReviewDto;
 import JesusDeciples.RankingQuiz.api.facade.QuizContentCreateFacade;
 import JesusDeciples.RankingQuiz.api.facade.QuizContentReadFacade;
 import JesusDeciples.RankingQuiz.api.service.BulkImportService;
+import JesusDeciples.RankingQuiz.api.service.quizContent.QuizContentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,6 +30,23 @@ public class QuizContentController {
     private final QuizContentCreateFacade quizContentCreateFacade;
     private final QuizContentReadFacade readFacade;
     private final BulkImportService bulkImportService;
+    private final QuizContentService quizContentService;
+
+    @GetMapping
+    @Operation(summary = "QuizContent 목록 조회 (관리자)",
+            description = "카테고리 및 정답 키워드로 필터링된 퀴즈 목록을 페이징하여 반환합니다.")
+    public ResponseEntity<Page<QuizContentReviewDto>> getQuizContents(
+            @RequestParam(required = false) QuizCategory category,
+            @RequestParam(required = false) String answer,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
+        Page<QuizContentReviewDto> result = quizContentService
+                .getQuizContentPage(category, answer, pageable)
+                .map(QuizContentReviewDto::of);
+        return ResponseEntity.ok(result);
+    }
+
     @PostMapping
     @Operation(summary = "QuizContent 등록",
             description = "주어진 QuizContentCreateDto 배열을 사용하여 퀴즈 콘텐츠를 등록합니다.")

--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/quizContent/QuizContentService.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/quizContent/QuizContentService.java
@@ -4,6 +4,8 @@ import JesusDeciples.RankingQuiz.api.dto.request.QuizContentCreateDto;
 import JesusDeciples.RankingQuiz.api.entity.quizContent.QuizContent;
 import JesusDeciples.RankingQuiz.api.entity.quizContent.ReferenceTag;
 import JesusDeciples.RankingQuiz.api.enums.QuizCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,6 +18,7 @@ public interface QuizContentService {
     QuizContent getRandomQuizContent(QuizCategory category);
     void saveToRepository(QuizContent entity);
     QuizContent getQuizContentById(Long id);
-
     List<QuizContent> findAllByReferenceTagIn(Set<ReferenceTag> tagSet);
+
+    Page<QuizContent> getQuizContentPage(QuizCategory category, String answer, Pageable pageable);
 }

--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/quizContent/QuizContentServiceImpl.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/quizContent/QuizContentServiceImpl.java
@@ -8,6 +8,8 @@ import JesusDeciples.RankingQuiz.api.repository.MultipleChoiceQuizContentReposit
 import JesusDeciples.RankingQuiz.api.repository.QuizContentRepository;
 import JesusDeciples.RankingQuiz.api.repository.ShortAnswerQuizContentRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -72,6 +74,22 @@ public class QuizContentServiceImpl implements QuizContentService {
     @Override
     public List<QuizContent> findAllByReferenceTagIn(Set<ReferenceTag> tagSet) {
         return repository.findDistinctAllByTagIn(tagSet);
+    }
+
+    @Override
+    public Page<QuizContent> getQuizContentPage(QuizCategory category, String answer, Pageable pageable) {
+        boolean hasCategory = category != null;
+        boolean hasAnswer = answer != null && !answer.isBlank();
+
+        if (hasCategory && hasAnswer) {
+            return repository.findByCategoryAndAnswerContainingIgnoreCase(category, answer, pageable);
+        } else if (hasCategory) {
+            return repository.findByCategory(category, pageable);
+        } else if (hasAnswer) {
+            return repository.findByAnswerContainingIgnoreCase(answer, pageable);
+        } else {
+            return repository.findAll(pageable);
+        }
     }
 }
 

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/response/QuizContentReviewDto.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/response/QuizContentReviewDto.java
@@ -23,6 +23,7 @@ public class QuizContentReviewDto {
         dto.setId(entity.getId());
         dto.setStatement(entity.getStatement());
         dto.setAnswer(entity.getAnswer());
+        dto.setCategory(entity.getCategory());
         if (entity instanceof MultipleChoiceQuizContent) {
             dto.setOptions(((MultipleChoiceQuizContent) entity).getOptions());
         }

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/repository/QuizContentRepository.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/repository/QuizContentRepository.java
@@ -2,6 +2,9 @@ package JesusDeciples.RankingQuiz.api.repository;
 
 import JesusDeciples.RankingQuiz.api.entity.quizContent.QuizContent;
 import JesusDeciples.RankingQuiz.api.entity.quizContent.ReferenceTag;
+import JesusDeciples.RankingQuiz.api.enums.QuizCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,4 +24,10 @@ public interface QuizContentRepository extends JpaRepository<QuizContent, Long> 
 
     @Query("SELECT DISTINCT qc FROM QuizContent qc JOIN FETCH qc.links link WHERE link.referenceTag IN :tags")
     List<QuizContent> findDistinctAllByTagIn(@Param("tags") Set<ReferenceTag> tagSet);
+
+    Page<QuizContent> findByCategory(QuizCategory category, Pageable pageable);
+
+    Page<QuizContent> findByAnswerContainingIgnoreCase(String answer, Pageable pageable);
+
+    Page<QuizContent> findByCategoryAndAnswerContainingIgnoreCase(QuizCategory category, String answer, Pageable pageable);
 }

--- a/RankingQuizFront/src/main/resources/static/js/admin.js
+++ b/RankingQuizFront/src/main/resources/static/js/admin.js
@@ -11,8 +11,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById('adminContent').classList.remove('hidden');
   initTabs();
-  initRadioCards();
-  initQuizTypeToggle();
   loadQuizStatus();
   loadSessionCounts();
   setInterval(loadSessionCounts, 15000);
@@ -23,51 +21,17 @@ document.addEventListener('DOMContentLoaded', () => {
 // 탭 전환
 // =============================================
 function initTabs() {
-  const tabs = ['home', 'register'];
-  tabs.forEach(name => {
+  ['home', 'manage'].forEach(name => {
     document.getElementById(`tab-${name}`).addEventListener('click', () => switchTab(name));
   });
 }
 
 function switchTab(name) {
-  ['home', 'register', 'bulk'].forEach(t => {
+  ['home', 'manage', 'bulk'].forEach(t => {
     document.getElementById(`tab-${t}`).classList.toggle('active', t === name);
     document.getElementById(`panel-${t}`).classList.toggle('hidden', t !== name);
   });
-}
-
-// =============================================
-// 라디오 카드 UX
-// =============================================
-function initRadioCards() {
-  document.querySelectorAll('.radio-card').forEach(card => {
-    card.addEventListener('click', () => {
-      const radio = card.querySelector('input[type="radio"]');
-      const name = radio.name;
-      document.querySelectorAll(`input[name="${name}"]`).forEach(r => {
-        r.closest('.radio-card').classList.remove('selected');
-      });
-      radio.checked = true;
-      card.classList.add('selected');
-    });
-  });
-
-  // 초기 선택 상태 반영
-  document.querySelectorAll('input[type="radio"]:checked').forEach(r => {
-    r.closest('.radio-card').classList.add('selected');
-  });
-}
-
-// =============================================
-// 문제 유형 변경 시 보기 섹션 토글
-// =============================================
-function initQuizTypeToggle() {
-  document.querySelectorAll('input[name="quizType"]').forEach(radio => {
-    radio.addEventListener('change', () => {
-      const isMultiple = radio.value === 'MULTIPLE_CHOICE';
-      document.getElementById('multipleOptionsSection').classList.toggle('hidden', !isMultiple);
-    });
-  });
+  if (name === 'manage') loadQuizList();
 }
 
 // =============================================
@@ -131,7 +95,6 @@ async function onToggleQuiz(category, enabled) {
     const label = category === 'ENG_VOCA' ? '단어 퀴즈' : '성경 퀴즈';
     showToast(`${label}가 ${enabled ? '활성화' : '비활성화'}되었습니다.`);
   } catch (e) {
-    // 실패 시 토글 원복
     const toggle = document.getElementById(`toggle-${category}`);
     if (toggle) toggle.checked = !enabled;
     showToast('변경 실패: ' + e.message);
@@ -154,94 +117,6 @@ function showToast(message) {
 }
 
 // =============================================
-// 보기 추가/제거
-// =============================================
-function addOption() {
-  const list = document.getElementById('optionsList');
-  const count = list.querySelectorAll('.option-input').length + 1;
-  const input = document.createElement('input');
-  input.type = 'text';
-  input.placeholder = `보기 ${count}`;
-  input.className = 'option-input neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-3 text-white placeholder-white/25 text-sm transition-all duration-200';
-  list.appendChild(input);
-}
-
-function removeOption() {
-  const list = document.getElementById('optionsList');
-  const inputs = list.querySelectorAll('.option-input');
-  if (inputs.length > 2) {
-    inputs[inputs.length - 1].remove();
-  }
-}
-
-// =============================================
-// 문제 등록 제출
-// =============================================
-async function submitQuiz() {
-  const statement = document.getElementById('statement').value.trim();
-  const answer = document.getElementById('answer').value.trim();
-  const timeLimit = parseInt(document.getElementById('timeLimit').value) || 10;
-  const category = document.querySelector('input[name="category"]:checked')?.value;
-  const quizType = document.querySelector('input[name="quizType"]:checked')?.value;
-  const tagsRaw = document.getElementById('tags').value.trim();
-  const tags = tagsRaw ? tagsRaw.split(',').map(t => t.trim()).filter(Boolean) : [];
-
-  if (!statement || !answer || !category || !quizType) {
-    showRegisterResult('문제 내용과 정답을 모두 입력해주세요.', false);
-    return;
-  }
-
-  const payload = { statement, answer, timeLimit, category, quizType, tags };
-
-  if (quizType === 'MULTIPLE_CHOICE') {
-    const options = [...document.querySelectorAll('.option-input')]
-      .map(i => i.value.trim())
-      .filter(Boolean);
-    if (options.length < 2) {
-      showRegisterResult('객관식은 보기를 최소 2개 이상 입력해주세요.', false);
-      return;
-    }
-    payload.multipleOptions = options;
-  }
-
-  const btn = document.getElementById('submitBtn');
-  btn.disabled = true;
-  btn.textContent = '등록 중...';
-
-  try {
-    const res = await fetch(`${protocol}${BACKEND_BASE_URL}/quiz-content`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`
-      },
-      body: JSON.stringify([payload])
-    });
-
-    if (!res.ok) {
-      const msg = res.status === 403 ? '관리자 권한이 필요합니다.' : '등록에 실패했습니다.';
-      throw new Error(msg);
-    }
-
-    showRegisterResult('✅ 문제가 등록되었습니다!', true);
-    resetForm();
-  } catch (e) {
-    showRegisterResult('❌ ' + e.message, false);
-  } finally {
-    btn.disabled = false;
-    btn.textContent = '문제 등록하기';
-  }
-}
-
-function showRegisterResult(message, success) {
-  const el = document.getElementById('registerResult');
-  el.textContent = message;
-  el.className = `text-center text-sm py-3 rounded-2xl ${success ? 'success' : 'error'}`;
-  el.classList.remove('hidden');
-  setTimeout(() => el.classList.add('hidden'), 3000);
-}
-
-// =============================================
 // 대량 등록
 // =============================================
 async function submitBulkImport() {
@@ -257,7 +132,7 @@ async function submitBulkImport() {
 
   try {
     const category = document.getElementById('bulkCategory').value;
-  const res = await fetch(`${protocol}${BACKEND_BASE_URL}/quiz-content/bulk-import?category=${category}`, {
+    const res = await fetch(`${protocol}${BACKEND_BASE_URL}/quiz-content/bulk-import?category=${category}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'text/plain;charset=UTF-8',
@@ -308,13 +183,282 @@ function showBulkResult(errors, success, savedCount) {
   });
 }
 
-function resetForm() {
-  document.getElementById('statement').value = '';
-  document.getElementById('answer').value = '';
-  document.getElementById('timeLimit').value = '10';
-  document.getElementById('tags').value = '';
-  document.querySelectorAll('.option-input').forEach((el, i) => {
-    el.value = '';
-    el.placeholder = `보기 ${i + 1}`;
+// =============================================
+// 개별 퀴즈 관리 — 목록 조회
+// =============================================
+const manageState = {
+  page: 0,
+  size: 10,
+  totalPages: 0,
+  category: '',
+  answer: '',
+};
+
+let quizDataMap = {};
+
+function onManageCategoryChange() {
+  manageState.category = document.getElementById('manageCategory').value;
+  manageState.page = 0;
+  loadQuizList();
+}
+
+function searchQuizList() {
+  manageState.answer = document.getElementById('manageKeyword').value.trim();
+  manageState.page = 0;
+  loadQuizList();
+}
+
+async function loadQuizList() {
+  const container = document.getElementById('quizListContainer');
+  container.innerHTML = '<div class="text-white/30 text-sm text-center py-8">목록을 불러오는 중...</div>';
+  document.getElementById('quizPagination').innerHTML = '';
+
+  const params = new URLSearchParams({ page: manageState.page, size: manageState.size });
+  if (manageState.category) params.set('category', manageState.category);
+  if (manageState.answer) params.set('answer', manageState.answer);
+
+  try {
+    const res = await fetch(`${protocol}${BACKEND_BASE_URL}/quiz-content?${params}`, {
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+    if (!res.ok) throw new Error(res.status === 403 ? '관리자 권한이 필요합니다.' : '목록 조회에 실패했습니다.');
+    const data = await res.json();
+    manageState.totalPages = data.totalPages ?? 0;
+    quizDataMap = {};
+    renderQuizList(data.content ?? []);
+    renderPagination();
+  } catch (e) {
+    container.innerHTML = `<div class="text-red-400 text-sm text-center py-8">오류: ${escapeHtml(e.message)}</div>`;
+  }
+}
+
+function renderQuizList(items) {
+  const container = document.getElementById('quizListContainer');
+
+  if (!items.length) {
+    container.innerHTML = '<div class="text-white/30 text-sm text-center py-8">등록된 퀴즈가 없습니다.</div>';
+    return;
+  }
+
+  container.innerHTML = '';
+  items.forEach(quiz => {
+    quizDataMap[quiz.id] = quiz;
+
+    const badge = quiz.category === 'ENG_VOCA'
+      ? '<span class="text-xs bg-neon-blue/10 text-neon-blue border border-neon-blue/20 rounded-lg px-2 py-0.5">단어</span>'
+      : '<span class="text-xs bg-neon-purple/10 text-neon-purple border border-neon-purple/20 rounded-lg px-2 py-0.5">성경</span>';
+
+    const optionsHtml = (quiz.options && quiz.options.length > 0)
+      ? `<div class="mb-2.5">
+          <p class="text-white/40 text-xs mb-1.5">보기</p>
+          <div class="flex flex-wrap gap-1.5">
+            ${quiz.options.map((opt, i) =>
+              `<span class="text-xs bg-white/5 border border-white/10 rounded-lg px-2.5 py-1 text-white/70">${i + 1}. ${escapeHtml(opt)}</span>`
+            ).join('')}
+          </div>
+        </div>`
+      : '';
+
+    const card = document.createElement('div');
+    card.className = 'card-glass rounded-2xl p-4 border border-white/5';
+    card.innerHTML = `
+      <div class="flex items-center justify-between mb-3">
+        <div class="flex items-center gap-2">
+          ${badge}
+          <span class="text-white/30 text-xs">#${quiz.id}</span>
+        </div>
+        <div class="flex gap-2">
+          <button onclick="openEditModal(${quiz.id})"
+            class="text-xs text-neon-blue/70 hover:text-neon-blue transition-colors px-3 py-1.5 rounded-xl border border-neon-blue/20 hover:border-neon-blue/50">
+            수정
+          </button>
+          <button onclick="openDeleteModal(${quiz.id})"
+            class="text-xs text-red-400/70 hover:text-red-400 transition-colors px-3 py-1.5 rounded-xl border border-red-500/20 hover:border-red-500/50">
+            삭제
+          </button>
+        </div>
+      </div>
+      <div class="mb-2.5">
+        <p class="text-white/40 text-xs mb-1">문제</p>
+        <p class="text-white text-sm leading-relaxed break-words">${escapeHtml(quiz.statement)}</p>
+      </div>
+      ${optionsHtml}
+      <div class="pt-2.5 border-t border-white/5">
+        <p class="text-white/40 text-xs mb-0.5">정답</p>
+        <p class="text-neon-blue font-bold text-sm">${escapeHtml(quiz.answer)}</p>
+      </div>
+    `;
+    container.appendChild(card);
   });
+}
+
+function renderPagination() {
+  const container = document.getElementById('quizPagination');
+  container.innerHTML = '';
+  if (manageState.totalPages <= 1) return;
+
+  const btnBase = 'w-9 h-9 rounded-xl text-sm font-bold transition-colors border';
+
+  const prev = document.createElement('button');
+  prev.className = `${btnBase} border-white/10 text-white/40 hover:text-white/70 disabled:opacity-30 disabled:cursor-not-allowed`;
+  prev.textContent = '‹';
+  prev.disabled = manageState.page === 0;
+  prev.onclick = () => { manageState.page--; loadQuizList(); };
+  container.appendChild(prev);
+
+  for (let i = 0; i < manageState.totalPages; i++) {
+    const btn = document.createElement('button');
+    btn.className = `${btnBase} ${i === manageState.page
+      ? 'bg-neon-blue/20 border-neon-blue/40 text-neon-blue'
+      : 'border-white/10 text-white/40 hover:text-white/70'}`;
+    btn.textContent = i + 1;
+    btn.onclick = () => { manageState.page = i; loadQuizList(); };
+    container.appendChild(btn);
+  }
+
+  const next = document.createElement('button');
+  next.className = `${btnBase} border-white/10 text-white/40 hover:text-white/70 disabled:opacity-30 disabled:cursor-not-allowed`;
+  next.textContent = '›';
+  next.disabled = manageState.page >= manageState.totalPages - 1;
+  next.onclick = () => { manageState.page++; loadQuizList(); };
+  container.appendChild(next);
+}
+
+// =============================================
+// 수정 모달
+// =============================================
+function openEditModal(quizId) {
+  const quiz = quizDataMap[quizId];
+  if (!quiz) return;
+
+  document.getElementById('editQuizId').value = quiz.id;
+  document.getElementById('editCategory').value =
+    quiz.category === 'ENG_VOCA' ? '📖 단어 퀴즈 (ENG_VOCA)' : '✝️ 성경 퀴즈 (BIBLE)';
+  document.getElementById('editStatement').value = quiz.statement;
+  document.getElementById('editAnswer').value = quiz.answer;
+
+  const optionsSection = document.getElementById('editOptionsSection');
+  const optionsList = document.getElementById('editOptionsList');
+  optionsList.innerHTML = '';
+
+  if (quiz.options && quiz.options.length > 0) {
+    optionsSection.classList.remove('hidden');
+    quiz.options.forEach((opt, i) => {
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.value = opt;
+      input.placeholder = `보기 ${i + 1}`;
+      input.className = 'neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-3 text-white placeholder-white/25 text-sm transition-all duration-200';
+      optionsList.appendChild(input);
+    });
+  } else {
+    optionsSection.classList.add('hidden');
+  }
+
+  document.getElementById('editResult').classList.add('hidden');
+  document.getElementById('editModal').classList.remove('hidden');
+  document.body.style.overflow = 'hidden';
+}
+
+function closeEditModal() {
+  document.getElementById('editModal').classList.add('hidden');
+  document.body.style.overflow = '';
+}
+
+async function submitEditQuiz() {
+  const id = document.getElementById('editQuizId').value;
+  const statement = document.getElementById('editStatement').value.trim();
+  const answer = document.getElementById('editAnswer').value.trim();
+
+  if (!statement || !answer) {
+    showEditResult('문제 내용과 정답을 입력해주세요.', false);
+    return;
+  }
+
+  const payload = { statement, answer };
+
+  const optionInputs = document.querySelectorAll('#editOptionsList input');
+  if (optionInputs.length > 0) {
+    const options = [...optionInputs].map(i => i.value.trim()).filter(Boolean);
+    if (options.length < 2) {
+      showEditResult('보기는 최소 2개 이상 입력해주세요.', false);
+      return;
+    }
+    payload.multipleOptions = options;
+  }
+
+  try {
+    const res = await fetch(`${protocol}${BACKEND_BASE_URL}/quiz-content/${id}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!res.ok) throw new Error(res.status === 403 ? '관리자 권한이 필요합니다.' : '수정에 실패했습니다.');
+    showEditResult('✅ 수정되었습니다.', true);
+    setTimeout(() => { closeEditModal(); loadQuizList(); }, 1200);
+  } catch (e) {
+    showEditResult('❌ ' + e.message, false);
+  }
+}
+
+function showEditResult(message, success) {
+  const el = document.getElementById('editResult');
+  el.textContent = message;
+  el.className = `text-center text-sm py-3 rounded-2xl ${success ? 'success' : 'error'}`;
+  el.classList.remove('hidden');
+}
+
+// =============================================
+// 삭제 모달
+// =============================================
+function openDeleteModal(quizId) {
+  const quiz = quizDataMap[quizId];
+  if (!quiz) return;
+
+  document.getElementById('deleteQuizId').value = quizId;
+  const preview = quiz.statement.length > 30
+    ? quiz.statement.substring(0, 30) + '...'
+    : quiz.statement;
+  document.getElementById('deleteConfirmText').textContent =
+    `"${preview}" 문제를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.`;
+
+  document.getElementById('deleteModal').classList.remove('hidden');
+  document.body.style.overflow = 'hidden';
+}
+
+function closeDeleteModal() {
+  document.getElementById('deleteModal').classList.add('hidden');
+  document.body.style.overflow = '';
+}
+
+async function confirmDeleteQuiz() {
+  const id = document.getElementById('deleteQuizId').value;
+  try {
+    const res = await fetch(`${protocol}${BACKEND_BASE_URL}/quiz-content/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+    if (!res.ok) throw new Error(res.status === 403 ? '관리자 권한이 필요합니다.' : '삭제에 실패했습니다.');
+    closeDeleteModal();
+    showToast('퀴즈가 삭제되었습니다.');
+    loadQuizList();
+  } catch (e) {
+    closeDeleteModal();
+    showToast('삭제 실패: ' + e.message);
+  }
+}
+
+// =============================================
+// 유틸
+// =============================================
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
 }

--- a/RankingQuizFront/src/main/resources/templates/admin/admin.html
+++ b/RankingQuizFront/src/main/resources/templates/admin/admin.html
@@ -31,9 +31,9 @@
           class="admin-tab active flex-1 py-3 rounded-2xl text-sm font-bold tracking-wide transition-all duration-200">
           🏠 퀴즈 현황
         </button>
-        <button id="tab-register"
+        <button id="tab-manage"
           class="admin-tab flex-1 py-3 rounded-2xl text-sm font-bold tracking-wide transition-all duration-200">
-          ✏️ 문제 등록
+          📝 개별 퀴즈 관리
         </button>
         <button id="tab-bulk"
           class="admin-tab flex-1 py-3 rounded-2xl text-sm font-bold tracking-wide transition-all duration-200">
@@ -98,120 +98,40 @@
         <div id="statusToast" class="hidden card-glass rounded-2xl px-5 py-3 text-sm text-center text-white/80"></div>
       </div>
 
-      <!-- ===== 탭 2: 문제 등록 ===== -->
-      <div id="panel-register" class="hidden">
+      <!-- ===== 탭 2: 개별 퀴즈 관리 ===== -->
+      <div id="panel-manage" class="hidden">
 
-        <p class="text-white/40 text-xs tracking-wider uppercase mb-4">퀴즈 문제 등록</p>
+        <p class="text-white/40 text-xs tracking-wider uppercase mb-4">개별 퀴즈 관리</p>
 
-        <div class="card-glass rounded-3xl p-6 space-y-5">
-
-          <!-- 카테고리 -->
-          <div>
-            <label class="field-label">카테고리</label>
-            <div class="grid grid-cols-2 gap-3 mt-2">
-              <label class="radio-card" id="radio-ENG_VOCA">
-                <input type="radio" name="category" value="ENG_VOCA" class="hidden" checked />
-                <span class="text-lg">📖</span>
-                <span class="text-sm font-bold">단어 퀴즈</span>
-              </label>
-              <label class="radio-card" id="radio-BIBLE">
-                <input type="radio" name="category" value="BIBLE" class="hidden" />
-                <span class="text-lg">✝️</span>
-                <span class="text-sm font-bold">성경 퀴즈</span>
-              </label>
-            </div>
+        <!-- 필터 및 검색 -->
+        <div class="card-glass rounded-3xl p-5 mb-4">
+          <div class="mb-3">
+            <select id="manageCategory" onchange="onManageCategoryChange()"
+              class="w-full bg-surface-base border border-white/10 rounded-xl px-4 py-3 text-white text-sm cursor-pointer transition-all duration-200">
+              <option value="">전체 카테고리</option>
+              <option value="ENG_VOCA">📖 단어 퀴즈 (ENG_VOCA)</option>
+              <option value="BIBLE">✝️ 성경 퀴즈 (BIBLE)</option>
+            </select>
           </div>
-
-          <!-- 문제 유형 -->
-          <div>
-            <label class="field-label">문제 유형</label>
-            <div class="grid grid-cols-2 gap-3 mt-2">
-              <label class="radio-card" id="radio-MULTIPLE_CHOICE">
-                <input type="radio" name="quizType" value="MULTIPLE_CHOICE" class="hidden" checked />
-                <span class="text-lg">🔘</span>
-                <span class="text-sm font-bold">객관식</span>
-              </label>
-              <label class="radio-card" id="radio-SHORT_ANSWER">
-                <input type="radio" name="quizType" value="SHORT_ANSWER_WRITING" class="hidden" />
-                <span class="text-lg">✍️</span>
-                <span class="text-sm font-bold">주관식</span>
-              </label>
-            </div>
+          <div class="flex gap-2">
+            <input type="text" id="manageKeyword" placeholder="정답으로 검색..."
+              class="flex-1 bg-white/5 border border-white/10 rounded-xl px-4 py-3 text-white placeholder-white/25 text-sm transition-all duration-200"
+              onkeydown="if(event.key==='Enter') searchQuizList()" />
+            <button onclick="searchQuizList()"
+              class="btn-glow-blue bg-gradient-to-br from-neon-blue to-neon-blue-dark text-surface-base font-bold rounded-xl px-5 py-3 text-sm">
+              검색
+            </button>
           </div>
-
-          <!-- 문제 내용 -->
-          <div>
-            <label class="field-label" for="statement">문제 내용</label>
-            <textarea
-              id="statement"
-              rows="3"
-              placeholder="문제를 입력하세요"
-              class="neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-4 text-white placeholder-white/25 text-sm resize-none mt-2 transition-all duration-200"
-            ></textarea>
-          </div>
-
-          <!-- 정답 -->
-          <div>
-            <label class="field-label" for="answer">정답</label>
-            <input
-              type="text"
-              id="answer"
-              placeholder="정답을 입력하세요"
-              class="neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-4 text-white placeholder-white/25 text-sm mt-2 transition-all duration-200"
-            />
-          </div>
-
-          <!-- 제한 시간 -->
-          <div>
-            <label class="field-label" for="timeLimit">제한 시간 (초)</label>
-            <input
-              type="number"
-              id="timeLimit"
-              value="10"
-              min="5"
-              max="60"
-              class="neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-4 text-white placeholder-white/25 text-sm mt-2 transition-all duration-200"
-            />
-          </div>
-
-          <!-- 보기 (객관식 전용) -->
-          <div id="multipleOptionsSection">
-            <label class="field-label">보기 (객관식)</label>
-            <div id="optionsList" class="space-y-2 mt-2">
-              <input type="text" placeholder="보기 1" class="option-input neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-3 text-white placeholder-white/25 text-sm transition-all duration-200" />
-              <input type="text" placeholder="보기 2" class="option-input neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-3 text-white placeholder-white/25 text-sm transition-all duration-200" />
-              <input type="text" placeholder="보기 3" class="option-input neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-3 text-white placeholder-white/25 text-sm transition-all duration-200" />
-              <input type="text" placeholder="보기 4" class="option-input neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-3 text-white placeholder-white/25 text-sm transition-all duration-200" />
-            </div>
-            <div class="flex gap-2 mt-2">
-              <button onclick="addOption()" class="text-xs text-neon-blue/70 hover:text-neon-blue transition-colors px-3 py-1.5 rounded-xl border border-neon-blue/20 hover:border-neon-blue/50">+ 보기 추가</button>
-              <button onclick="removeOption()" class="text-xs text-white/30 hover:text-white/60 transition-colors px-3 py-1.5 rounded-xl border border-white/10 hover:border-white/30">− 보기 제거</button>
-            </div>
-          </div>
-
-          <!-- 태그 -->
-          <div>
-            <label class="field-label" for="tags">태그 (쉼표 구분, 선택사항)</label>
-            <input
-              type="text"
-              id="tags"
-              placeholder="예: 창세기, 신약, 어원"
-              class="neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-4 text-white placeholder-white/25 text-sm mt-2 transition-all duration-200"
-            />
-          </div>
-
-          <!-- 등록 버튼 -->
-          <button
-            id="submitBtn"
-            onclick="submitQuiz()"
-            class="btn-glow-blue w-full bg-gradient-to-br from-neon-blue to-neon-blue-dark text-surface-base font-bold rounded-2xl py-4 text-sm tracking-wide mt-2"
-          >
-            문제 등록하기
-          </button>
-
-          <!-- 결과 메시지 -->
-          <div id="registerResult" class="hidden text-center text-sm py-3 rounded-2xl"></div>
         </div>
+
+        <!-- 퀴즈 목록 -->
+        <div id="quizListContainer" class="space-y-2 mb-4">
+          <div class="text-white/30 text-sm text-center py-8">탭을 선택하면 목록이 로드됩니다.</div>
+        </div>
+
+        <!-- 페이징 -->
+        <div id="quizPagination" class="flex justify-center gap-2 mb-4"></div>
+
       </div>
       <!-- ===== 탭 3: 대량 등록 ===== -->
       <div id="panel-bulk" class="hidden">
@@ -269,6 +189,74 @@
 
     <!-- Footer -->
     <div th:replace="~{fragments/footer :: footer}"></div>
+  </div>
+
+  <!-- ===== 수정 모달 ===== -->
+  <div id="editModal" class="fixed inset-0 z-50 hidden flex items-end justify-center">
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" onclick="closeEditModal()"></div>
+    <div class="relative w-full max-w-lg bg-surface-base border border-white/10 rounded-t-3xl p-6 space-y-4 max-h-[85vh] overflow-y-auto">
+      <div class="flex items-center justify-between mb-2">
+        <h3 class="font-bold text-base">퀴즈 수정</h3>
+        <button onclick="closeEditModal()" class="text-white/40 hover:text-white/70 text-xl leading-none">✕</button>
+      </div>
+
+      <input type="hidden" id="editQuizId" />
+
+      <div>
+        <label class="field-label">카테고리</label>
+        <input type="text" id="editCategory" readonly
+          class="w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-3 text-white/50 text-sm mt-2 cursor-not-allowed" />
+      </div>
+
+      <div>
+        <label class="field-label" for="editStatement">문제 내용</label>
+        <textarea id="editStatement" rows="3" placeholder="문제를 입력하세요"
+          class="neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-4 text-white placeholder-white/25 text-sm resize-none mt-2 transition-all duration-200"></textarea>
+      </div>
+
+      <div>
+        <label class="field-label" for="editAnswer">정답</label>
+        <input type="text" id="editAnswer" placeholder="정답을 입력하세요"
+          class="neon-border w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-4 text-white placeholder-white/25 text-sm mt-2 transition-all duration-200" />
+      </div>
+
+      <div id="editOptionsSection" class="hidden">
+        <label class="field-label">보기 (객관식)</label>
+        <div id="editOptionsList" class="space-y-2 mt-2"></div>
+      </div>
+
+      <div class="flex gap-3 pt-2">
+        <button onclick="closeEditModal()"
+          class="flex-1 py-3 rounded-2xl border border-white/10 text-white/60 text-sm font-bold hover:border-white/30 transition-colors">
+          취소
+        </button>
+        <button onclick="submitEditQuiz()"
+          class="flex-1 btn-glow-blue bg-gradient-to-br from-neon-blue to-neon-blue-dark text-surface-base font-bold rounded-2xl py-3 text-sm">
+          저장
+        </button>
+      </div>
+      <div id="editResult" class="hidden text-center text-sm py-3 rounded-2xl"></div>
+    </div>
+  </div>
+
+  <!-- ===== 삭제 확인 모달 ===== -->
+  <div id="deleteModal" class="fixed inset-0 z-50 hidden flex items-center justify-center">
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" onclick="closeDeleteModal()"></div>
+    <div class="relative mx-5 w-full max-w-sm bg-surface-base border border-white/10 rounded-3xl p-6 space-y-4">
+      <h3 class="font-bold text-base text-center">퀴즈 삭제</h3>
+      <p class="text-white/60 text-sm text-center leading-relaxed" id="deleteConfirmText"></p>
+      <input type="hidden" id="deleteQuizId" />
+      <div class="flex gap-3">
+        <button onclick="closeDeleteModal()"
+          class="flex-1 py-3 rounded-2xl border border-white/10 text-white/60 text-sm font-bold hover:border-white/30 transition-colors">
+          취소
+        </button>
+        <button onclick="confirmDeleteQuiz()"
+          class="flex-1 py-3 rounded-2xl bg-red-500/20 border border-red-500/40 text-red-400 font-bold text-sm hover:bg-red-500/30 transition-colors">
+          삭제
+        </button>
+      </div>
+    </div>
   </div>
 
   <script th:src="@{/js/config.js}"></script>


### PR DESCRIPTION
## Summary
- 개별 퀴즈 등록 방식을 퀴즈 관리 탭으로 대체

## Changes
- 관리자 페이지에 퀴즈 관리 탭 구현
- 기존 개별 퀴즈 등록 방식 제거 및 통합 관리 UI 적용

## Test plan
- [ ] 관리자 로그인 후 퀴즈 관리 탭 진입 확인
- [ ] 퀴즈 목록 조회 및 관리 기능 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)