### PR TITLE
feat: 관리자 문제 신고 관리 기능 구현

### DIFF
--- a/RankingQuiz/admin/src/main/java/JesusDeciples/RankingQuiz/api/admin/controller/AdminReportController.java
+++ b/RankingQuiz/admin/src/main/java/JesusDeciples/RankingQuiz/api/admin/controller/AdminReportController.java
@@ -1,0 +1,4 @@
+package JesusDeciples.RankingQuiz.api.admin.controller;
+
+// AdminReportController is located in the app module at:
+// JesusDeciples.RankingQuiz.api.controller.AdminReportController

--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/config/SecurityConfig.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/config/SecurityConfig.java
@@ -34,8 +34,10 @@ public class SecurityConfig {
                         .requestMatchers("/api/quiz-status/public").permitAll()
                         .requestMatchers("/api/quiz-status/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers("/api/quiz-sessions/**").hasAuthority("ROLE_ADMIN")
+                        .requestMatchers("/api/admin/quiz/reports/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers("/api/member/**").authenticated()
                         .requestMatchers("/api/quiz-results/**").authenticated()
+                        .requestMatchers("/api/quiz/reports").authenticated()
                         .anyRequest().permitAll()
                 )
                 .addFilterBefore(new JWTFilter(jwtProducer), UsernamePasswordAuthenticationFilter.class);

--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/controller/AdminReportController.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/controller/AdminReportController.java
@@ -1,0 +1,44 @@
+package JesusDeciples.RankingQuiz.api.controller;
+
+import JesusDeciples.RankingQuiz.api.dto.request.ReportStatusUpdateDto;
+import JesusDeciples.RankingQuiz.api.dto.response.QuizReportDetailDto;
+import JesusDeciples.RankingQuiz.api.dto.response.QuizReportSummaryDto;
+import JesusDeciples.RankingQuiz.api.service.QuizReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/quiz/reports")
+@CrossOrigin(origins = {"http://localhost:8081", "https://rankingquiz.rivercastleworks.site"})
+@Tag(name = "AdminReport API", description = "퀴즈 문제 신고 관리자 API")
+public class AdminReportController {
+
+    private final QuizReportService quizReportService;
+
+    @GetMapping
+    @Operation(summary = "신고 목록 조회", description = "삭제되지 않은 신고 내역을 최신순으로 반환합니다.")
+    public ResponseEntity<List<QuizReportSummaryDto>> getAllReports() {
+        return ResponseEntity.ok(quizReportService.getAllActiveReports());
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "신고 상세 조회", description = "특정 신고 내역의 상세 정보를 반환합니다.")
+    public ResponseEntity<QuizReportDetailDto> getReportDetail(@PathVariable("id") Long id) {
+        return ResponseEntity.ok(quizReportService.getReportDetail(id));
+    }
+
+    @PatchMapping("/{id}")
+    @Operation(summary = "신고 상태 변경", description = "신고 상태를 RESOLVED 또는 DELETED로 변경합니다.")
+    public ResponseEntity<Void> updateReportStatus(
+            @PathVariable("id") Long id,
+            @RequestBody ReportStatusUpdateDto dto) {
+        quizReportService.updateReportStatus(id, dto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/controller/QuizReportController.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/controller/QuizReportController.java
@@ -1,0 +1,26 @@
+package JesusDeciples.RankingQuiz.api.controller;
+
+import JesusDeciples.RankingQuiz.api.dto.request.QuizReportCreateDto;
+import JesusDeciples.RankingQuiz.api.service.QuizReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/quiz/reports")
+@CrossOrigin(origins = {"http://localhost:8081", "https://rankingquiz.rivercastleworks.site"})
+@Tag(name = "QuizReport API", description = "퀴즈 문제 신고 API")
+public class QuizReportController {
+
+    private final QuizReportService quizReportService;
+
+    @PostMapping
+    @Operation(summary = "퀴즈 문제 신고", description = "사용자가 퀴즈 문제의 이상을 신고합니다.")
+    public ResponseEntity<Void> createReport(@RequestBody QuizReportCreateDto dto) {
+        quizReportService.createReport(dto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/QuizReportService.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/QuizReportService.java
@@ -1,0 +1,15 @@
+package JesusDeciples.RankingQuiz.api.service;
+
+import JesusDeciples.RankingQuiz.api.dto.request.QuizReportCreateDto;
+import JesusDeciples.RankingQuiz.api.dto.request.ReportStatusUpdateDto;
+import JesusDeciples.RankingQuiz.api.dto.response.QuizReportDetailDto;
+import JesusDeciples.RankingQuiz.api.dto.response.QuizReportSummaryDto;
+
+import java.util.List;
+
+public interface QuizReportService {
+    void createReport(QuizReportCreateDto dto);
+    List<QuizReportSummaryDto> getAllActiveReports();
+    QuizReportDetailDto getReportDetail(Long id);
+    void updateReportStatus(Long id, ReportStatusUpdateDto dto);
+}

--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/QuizReportServiceImpl.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/QuizReportServiceImpl.java
@@ -1,0 +1,54 @@
+package JesusDeciples.RankingQuiz.api.service;
+
+import JesusDeciples.RankingQuiz.api.dto.request.QuizReportCreateDto;
+import JesusDeciples.RankingQuiz.api.dto.request.ReportStatusUpdateDto;
+import JesusDeciples.RankingQuiz.api.dto.response.QuizReportDetailDto;
+import JesusDeciples.RankingQuiz.api.dto.response.QuizReportSummaryDto;
+import JesusDeciples.RankingQuiz.api.entity.QuizReport;
+import JesusDeciples.RankingQuiz.api.enums.ReportStatus;
+import JesusDeciples.RankingQuiz.api.repository.QuizReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class QuizReportServiceImpl implements QuizReportService {
+
+    private final QuizReportRepository quizReportRepository;
+
+    @Override
+    @Transactional
+    public void createReport(QuizReportCreateDto dto) {
+        quizReportRepository.save(QuizReport.from(dto));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<QuizReportSummaryDto> getAllActiveReports() {
+        return quizReportRepository
+                .findAllByStatusNotOrderByReportedAtDesc(ReportStatus.DELETED)
+                .stream()
+                .map(QuizReportSummaryDto::from)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public QuizReportDetailDto getReportDetail(Long id) {
+        QuizReport report = quizReportRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("신고 내역을 찾을 수 없습니다. id=" + id));
+        return QuizReportDetailDto.from(report);
+    }
+
+    @Override
+    @Transactional
+    public void updateReportStatus(Long id, ReportStatusUpdateDto dto) {
+        QuizReport report = quizReportRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("신고 내역을 찾을 수 없습니다. id=" + id));
+        report.updateStatus(dto.getStatus());
+    }
+}

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/request/QuizReportCreateDto.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/request/QuizReportCreateDto.java
@@ -1,0 +1,14 @@
+package JesusDeciples.RankingQuiz.api.dto.request;
+
+import JesusDeciples.RankingQuiz.api.enums.QuizCategory;
+import lombok.Data;
+
+@Data
+public class QuizReportCreateDto {
+    private Long quizId;
+    private QuizCategory category;
+    private String question;
+    private String originalAnswer;
+    private String userAnswer;
+    private String reporterId;
+}

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/request/ReportStatusUpdateDto.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/request/ReportStatusUpdateDto.java
@@ -1,0 +1,9 @@
+package JesusDeciples.RankingQuiz.api.dto.request;
+
+import JesusDeciples.RankingQuiz.api.enums.ReportStatus;
+import lombok.Data;
+
+@Data
+public class ReportStatusUpdateDto {
+    private ReportStatus status;
+}

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/response/QuizReportDetailDto.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/response/QuizReportDetailDto.java
@@ -1,0 +1,37 @@
+package JesusDeciples.RankingQuiz.api.dto.response;
+
+import JesusDeciples.RankingQuiz.api.entity.QuizReport;
+import JesusDeciples.RankingQuiz.api.enums.QuizCategory;
+import JesusDeciples.RankingQuiz.api.enums.ReportStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class QuizReportDetailDto {
+    private final Long id;
+    private final Long quizId;
+    private final QuizCategory category;
+    private final String question;
+    private final String originalAnswer;
+    private final String userAnswer;
+    private final String reporterId;
+    private final LocalDateTime reportedAt;
+    private final ReportStatus status;
+
+    private QuizReportDetailDto(QuizReport report) {
+        this.id = report.getId();
+        this.quizId = report.getQuizId();
+        this.category = report.getCategory();
+        this.question = report.getQuestion();
+        this.originalAnswer = report.getOriginalAnswer();
+        this.userAnswer = report.getUserAnswer();
+        this.reporterId = report.getReporterId();
+        this.reportedAt = report.getReportedAt();
+        this.status = report.getStatus();
+    }
+
+    public static QuizReportDetailDto from(QuizReport report) {
+        return new QuizReportDetailDto(report);
+    }
+}

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/response/QuizReportSummaryDto.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/response/QuizReportSummaryDto.java
@@ -1,0 +1,33 @@
+package JesusDeciples.RankingQuiz.api.dto.response;
+
+import JesusDeciples.RankingQuiz.api.entity.QuizReport;
+import JesusDeciples.RankingQuiz.api.enums.QuizCategory;
+import JesusDeciples.RankingQuiz.api.enums.ReportStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class QuizReportSummaryDto {
+    private final Long id;
+    private final Long quizId;
+    private final QuizCategory category;
+    private final String question;
+    private final String reporterId;
+    private final ReportStatus status;
+    private final LocalDateTime reportedAt;
+
+    private QuizReportSummaryDto(QuizReport report) {
+        this.id = report.getId();
+        this.quizId = report.getQuizId();
+        this.category = report.getCategory();
+        this.question = report.getQuestion();
+        this.reporterId = report.getReporterId();
+        this.status = report.getStatus();
+        this.reportedAt = report.getReportedAt();
+    }
+
+    public static QuizReportSummaryDto from(QuizReport report) {
+        return new QuizReportSummaryDto(report);
+    }
+}

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/entity/QuizReport.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/entity/QuizReport.java
@@ -1,0 +1,62 @@
+package JesusDeciples.RankingQuiz.api.entity;
+
+import JesusDeciples.RankingQuiz.api.dto.request.QuizReportCreateDto;
+import JesusDeciples.RankingQuiz.api.enums.QuizCategory;
+import JesusDeciples.RankingQuiz.api.enums.ReportStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class QuizReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long quizId;
+
+    @Enumerated(EnumType.STRING)
+    private QuizCategory category;
+
+    @Column(length = 1000)
+    private String question;
+
+    private String originalAnswer;
+
+    private String userAnswer;
+
+    private String reporterId;
+
+    @Enumerated(EnumType.STRING)
+    private ReportStatus status;
+
+    private LocalDateTime reportedAt;
+
+    @PrePersist
+    private void onCreate() {
+        this.reportedAt = LocalDateTime.now();
+        if (this.status == null) {
+            this.status = ReportStatus.UNREAD;
+        }
+    }
+
+    public static QuizReport from(QuizReportCreateDto dto) {
+        QuizReport report = new QuizReport();
+        report.quizId = dto.getQuizId();
+        report.category = dto.getCategory();
+        report.question = dto.getQuestion();
+        report.originalAnswer = dto.getOriginalAnswer();
+        report.userAnswer = dto.getUserAnswer();
+        report.reporterId = dto.getReporterId();
+        return report;
+    }
+
+    public void updateStatus(ReportStatus status) {
+        this.status = status;
+    }
+}

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/enums/ReportStatus.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/enums/ReportStatus.java
@@ -1,0 +1,5 @@
+package JesusDeciples.RankingQuiz.api.enums;
+
+public enum ReportStatus {
+    UNREAD, RESOLVED, DELETED
+}

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/repository/QuizReportRepository.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/repository/QuizReportRepository.java
@@ -1,0 +1,11 @@
+package JesusDeciples.RankingQuiz.api.repository;
+
+import JesusDeciples.RankingQuiz.api.entity.QuizReport;
+import JesusDeciples.RankingQuiz.api.enums.ReportStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface QuizReportRepository extends JpaRepository<QuizReport, Long> {
+    List<QuizReport> findAllByStatusNotOrderByReportedAtDesc(ReportStatus status);
+}

--- a/RankingQuizFront/src/main/java/rankingquizfront/admin/controller/AdminPageController.java
+++ b/RankingQuizFront/src/main/java/rankingquizfront/admin/controller/AdminPageController.java
@@ -17,4 +17,9 @@ public class AdminPageController {
     public String adminLogin() {
         return "admin/admin-login";
     }
+
+    @GetMapping("/reports")
+    public String adminReports() {
+        return "admin/admin-reports";
+    }
 }

--- a/RankingQuizFront/src/main/resources/static/js/admin-reports.js
+++ b/RankingQuizFront/src/main/resources/static/js/admin-reports.js
@@ -1,0 +1,203 @@
+// =============================================
+// 인증 확인 및 초기화
+// =============================================
+const accessToken = sessionStorage.getItem('adminToken');
+
+let currentReportId = null;
+let currentQuizId = null;
+let allReports = [];
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (!accessToken) {
+    window.location.href = '/admin/login';
+    return;
+  }
+  document.getElementById('reportsContent').classList.remove('hidden');
+  loadReports();
+});
+
+// =============================================
+// 신고 목록 조회
+// =============================================
+async function loadReports() {
+  try {
+    const res = await fetch(`${protocol}${BACKEND_BASE_URL}/admin/quiz/reports`, {
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+    if (!res.ok) throw new Error('권한이 없습니다.');
+    allReports = await res.json();
+    renderReports(allReports);
+    updateStats(allReports);
+  } catch (e) {
+    showToast('목록 조회 실패: ' + e.message);
+  }
+}
+
+function updateStats(reports) {
+  document.getElementById('count-total').textContent = reports.length;
+  document.getElementById('count-unread').textContent = reports.filter(r => r.status === 'UNREAD').length;
+  document.getElementById('count-resolved').textContent = reports.filter(r => r.status === 'RESOLVED').length;
+}
+
+function renderReports(reports) {
+  const list = document.getElementById('reportsList');
+  const empty = document.getElementById('emptyState');
+  list.innerHTML = '';
+
+  if (reports.length === 0) {
+    empty.classList.remove('hidden');
+    return;
+  }
+  empty.classList.add('hidden');
+
+  reports.forEach(report => {
+    const card = document.createElement('div');
+    card.className = 'card-glass rounded-2xl p-4 cursor-pointer hover:bg-white/5 transition-all';
+    card.onclick = () => openModal(report.id);
+
+    const statusClass = report.status === 'UNREAD'
+      ? 'bg-neon-blue/10 border border-neon-blue/30 text-neon-blue'
+      : 'bg-neon-purple/10 border border-neon-purple/30 text-neon-purple';
+    const statusLabel = statusLabelOf(report.status);
+    const categoryLabel = categoryLabelOf(report.category);
+    const dateStr = formatDate(report.reportedAt);
+
+    card.innerHTML = `
+      <div class="flex items-start justify-between gap-3 mb-2">
+        <span class="inline-block px-2.5 py-0.5 rounded-full text-xs font-bold ${statusClass}">${statusLabel}</span>
+        <span class="text-white/30 text-xs flex-shrink-0">${dateStr}</span>
+      </div>
+      <p class="text-white/80 text-sm leading-relaxed line-clamp-2 mb-2">${escapeHtml(report.question)}</p>
+      <div class="flex items-center gap-3 text-xs text-white/40">
+        <span>📂 ${categoryLabel}</span>
+        <span>👤 ${escapeHtml(report.reporterId ?? '알 수 없음')}</span>
+      </div>
+    `;
+    list.appendChild(card);
+  });
+}
+
+// =============================================
+// 모달 열기 / 닫기
+// =============================================
+async function openModal(id) {
+  try {
+    const res = await fetch(`${protocol}${BACKEND_BASE_URL}/admin/quiz/reports/${id}`, {
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+    if (!res.ok) throw new Error('상세 조회 실패');
+    const report = await res.json();
+
+    currentReportId = report.id;
+    currentQuizId = report.quizId;
+
+    const statusClass = report.status === 'UNREAD'
+      ? 'bg-neon-blue/10 border border-neon-blue/30 text-neon-blue'
+      : 'bg-neon-purple/10 border border-neon-purple/30 text-neon-purple';
+
+    document.getElementById('modal-status-badge').className =
+      `inline-block px-3 py-1 rounded-full text-xs font-bold border ${statusClass}`;
+    document.getElementById('modal-status-badge').textContent = statusLabelOf(report.status);
+    document.getElementById('modal-meta').textContent =
+      `${categoryLabelOf(report.category)} · ${formatDate(report.reportedAt)}`;
+    document.getElementById('modal-question').textContent = report.question ?? '-';
+    document.getElementById('modal-original-answer').textContent = report.originalAnswer ?? '-';
+    document.getElementById('modal-user-answer').textContent = report.userAnswer ?? '(없음)';
+    document.getElementById('modal-reporter').textContent = report.reporterId ?? '알 수 없음';
+
+    const isResolved = report.status === 'RESOLVED';
+    document.getElementById('btn-resolve').disabled = isResolved;
+    document.getElementById('btn-resolve').classList.toggle('opacity-40', isResolved);
+
+    document.getElementById('reportModal').classList.remove('hidden');
+  } catch (e) {
+    showToast('상세 조회 실패: ' + e.message);
+  }
+}
+
+function closeModal() {
+  document.getElementById('reportModal').classList.add('hidden');
+  currentReportId = null;
+  currentQuizId = null;
+}
+
+// =============================================
+// 액션 버튼
+// =============================================
+function goToEdit() {
+  if (currentQuizId == null) return;
+  window.location.href = `/admin?quizId=${currentQuizId}`;
+}
+
+async function resolveReport() {
+  if (currentReportId == null) return;
+  await patchStatus(currentReportId, 'RESOLVED');
+}
+
+async function deleteReport() {
+  if (currentReportId == null) return;
+  await patchStatus(currentReportId, 'DELETED');
+}
+
+async function patchStatus(id, status) {
+  try {
+    const res = await fetch(`${protocol}${BACKEND_BASE_URL}/admin/quiz/reports/${id}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`
+      },
+      body: JSON.stringify({ status })
+    });
+    if (!res.ok) throw new Error('상태 변경 실패');
+
+    const label = status === 'RESOLVED' ? '해결 완료' : '삭제';
+    showToast(`✅ ${label} 처리되었습니다.`);
+    closeModal();
+    await loadReports();
+  } catch (e) {
+    showToast('처리 실패: ' + e.message);
+  }
+}
+
+// =============================================
+// 유틸리티
+// =============================================
+function statusLabelOf(status) {
+  switch (status) {
+    case 'UNREAD':    return '미확인';
+    case 'RESOLVED':  return '해결 완료';
+    case 'DELETED':   return '삭제됨';
+    default:          return status;
+  }
+}
+
+function categoryLabelOf(category) {
+  switch (category) {
+    case 'ENG_VOCA': return '단어 퀴즈';
+    case 'BIBLE':    return '성경 퀴즈';
+    default:         return category ?? '-';
+  }
+}
+
+function formatDate(dateStr) {
+  if (!dateStr) return '-';
+  const d = new Date(dateStr);
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+function escapeHtml(str) {
+  if (!str) return '';
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+let toastTimer;
+function showToast(message) {
+  const toast = document.getElementById('toast');
+  clearTimeout(toastTimer);
+  toast.textContent = message;
+  toast.classList.remove('hidden', 'opacity-0');
+  toastTimer = setTimeout(() => {
+    toast.classList.add('hidden');
+  }, 2500);
+}

--- a/RankingQuizFront/src/main/resources/templates/admin/admin-reports.html
+++ b/RankingQuizFront/src/main/resources/templates/admin/admin-reports.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+
+<head th:replace="~{fragments/head :: head('신고 관리 - RankingQuiz', @{/css/admin.css})}"></head>
+
+<body class="font-display min-h-screen bg-surface-base text-white overflow-x-hidden">
+
+  <!-- Background effects -->
+  <div class="fixed inset-0 bg-grid pointer-events-none"></div>
+  <div class="fixed top-[-20%] left-[-10%] w-[500px] h-[500px] bg-neon-blue opacity-[0.06] rounded-full blur-[100px] pointer-events-none"></div>
+  <div class="fixed bottom-[-20%] right-[-10%] w-[500px] h-[500px] bg-neon-purple opacity-[0.06] rounded-full blur-[100px] pointer-events-none"></div>
+
+  <div class="relative z-10 flex flex-col min-h-screen max-w-2xl mx-auto px-5 pb-10">
+
+    <!-- Header -->
+    <header class="pt-10 pb-6 flex items-center justify-between">
+      <div>
+        <p class="text-white/40 text-xs tracking-widest uppercase mb-1">Admin Panel</p>
+        <h1 class="brand-font text-3xl leading-none">
+          <span class="text-white">Ranking</span><span class="text-neon-blue neon-text">Quiz</span>
+          <span class="text-white/60 text-xl ml-2">신고 관리</span>
+        </h1>
+      </div>
+      <div class="flex items-center gap-4">
+        <a href="/admin" class="text-white/40 hover:text-white/70 text-sm transition-colors">← 관리 홈</a>
+      </div>
+    </header>
+
+    <!-- Content -->
+    <div id="reportsContent" class="hidden">
+
+      <!-- 상단 통계 -->
+      <div class="grid grid-cols-3 gap-3 mb-6">
+        <div class="card-glass rounded-2xl p-4 text-center">
+          <p class="text-white/40 text-xs uppercase tracking-wide mb-1">전체 신고</p>
+          <p id="count-total" class="text-2xl font-bold text-white">-</p>
+        </div>
+        <div class="card-glass rounded-2xl p-4 text-center">
+          <p class="text-white/40 text-xs uppercase tracking-wide mb-1">미확인</p>
+          <p id="count-unread" class="text-2xl font-bold text-neon-blue">-</p>
+        </div>
+        <div class="card-glass rounded-2xl p-4 text-center">
+          <p class="text-white/40 text-xs uppercase tracking-wide mb-1">해결 완료</p>
+          <p id="count-resolved" class="text-2xl font-bold text-neon-purple">-</p>
+        </div>
+      </div>
+
+      <!-- 신고 목록 -->
+      <p class="text-white/40 text-xs tracking-wider uppercase mb-3">신고 내역</p>
+
+      <div id="reportsList" class="space-y-3"></div>
+
+      <div id="emptyState" class="hidden card-glass rounded-3xl p-10 text-center">
+        <p class="text-4xl mb-3">✅</p>
+        <p class="text-white/60 text-sm">처리되지 않은 신고가 없습니다.</p>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ===== 상세 보기 모달 ===== -->
+  <div id="reportModal" class="hidden fixed inset-0 z-50 flex items-center justify-center px-5">
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" onclick="closeModal()"></div>
+    <div class="relative w-full max-w-lg card-glass rounded-3xl p-6 space-y-5 max-h-[90vh] overflow-y-auto">
+
+      <!-- 모달 헤더 -->
+      <div class="flex items-start justify-between">
+        <div>
+          <span id="modal-status-badge" class="inline-block px-3 py-1 rounded-full text-xs font-bold mb-2"></span>
+          <h2 class="text-lg font-bold">신고 상세</h2>
+          <p id="modal-meta" class="text-white/40 text-xs mt-0.5"></p>
+        </div>
+        <button onclick="closeModal()" class="text-white/40 hover:text-white/70 text-xl transition-colors ml-4">✕</button>
+      </div>
+
+      <!-- 문제 비교 -->
+      <div class="space-y-3">
+        <div class="bg-white/5 border border-white/10 rounded-2xl p-4">
+          <p class="text-white/40 text-xs uppercase tracking-wide mb-2">신고된 문제</p>
+          <p id="modal-question" class="text-white text-sm leading-relaxed"></p>
+        </div>
+
+        <div class="grid grid-cols-2 gap-3">
+          <div class="bg-neon-blue/5 border border-neon-blue/20 rounded-2xl p-4">
+            <p class="text-neon-blue/60 text-xs uppercase tracking-wide mb-2">원본 정답</p>
+            <p id="modal-original-answer" class="text-white font-bold text-sm"></p>
+          </div>
+          <div class="bg-white/5 border border-white/10 rounded-2xl p-4">
+            <p class="text-white/40 text-xs uppercase tracking-wide mb-2">사용자 답변</p>
+            <p id="modal-user-answer" class="text-white/80 text-sm"></p>
+          </div>
+        </div>
+      </div>
+
+      <!-- 신고자 정보 -->
+      <div class="bg-white/5 border border-white/10 rounded-2xl p-4 flex items-center gap-3">
+        <span class="text-2xl">👤</span>
+        <div>
+          <p class="text-white/40 text-xs uppercase tracking-wide">신고자 ID</p>
+          <p id="modal-reporter" class="text-white text-sm font-medium mt-0.5"></p>
+        </div>
+      </div>
+
+      <!-- 액션 버튼 -->
+      <div class="space-y-2 pt-1">
+        <button id="btn-edit" onclick="goToEdit()" class="w-full py-3 rounded-2xl text-sm font-bold tracking-wide border border-white/20 text-white/70 hover:bg-white/5 hover:text-white transition-all">
+          ✏️ 문제 수정하러 가기
+        </button>
+        <button id="btn-resolve" onclick="resolveReport()" class="w-full py-3 rounded-2xl text-sm font-bold tracking-wide bg-neon-blue/10 border border-neon-blue/30 text-neon-blue hover:bg-neon-blue/20 transition-all">
+          ✅ 해결 완료
+        </button>
+        <button id="btn-delete" onclick="deleteReport()" class="w-full py-3 rounded-2xl text-sm font-bold tracking-wide bg-red-500/10 border border-red-500/30 text-red-400 hover:bg-red-500/20 transition-all">
+          🗑️ 삭제 (심각한 오류)
+        </button>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- 토스트 -->
+  <div id="toast" class="hidden fixed bottom-8 left-1/2 -translate-x-1/2 z-[100] card-glass rounded-2xl px-6 py-3 text-sm text-center text-white/90 transition-opacity"></div>
+
+  <script th:src="@{/js/config.js}"></script>
+  <script th:src="@{/js/admin-reports.js}"></script>
+
+</body>
+</html>

--- a/RankingQuizFront/src/main/resources/templates/admin/admin.html
+++ b/RankingQuizFront/src/main/resources/templates/admin/admin.html
@@ -26,6 +26,22 @@
 
     <!-- 탭 네비게이션 -->
     <div id="adminContent" class="hidden">
+
+      <!-- 신고 관리 바로가기 -->
+      <a href="/admin/reports"
+        class="flex items-center justify-between card-glass rounded-2xl px-5 py-4 mb-5 hover:bg-white/5 transition-all group">
+        <div class="flex items-center gap-3">
+          <div class="w-10 h-10 rounded-xl bg-red-500/10 border border-red-500/20 flex items-center justify-center text-xl">
+            🚨
+          </div>
+          <div>
+            <p class="font-bold text-sm text-white">문제 신고 관리</p>
+            <p class="text-white/40 text-xs mt-0.5">사용자 신고 접수 내역 확인 및 처리</p>
+          </div>
+        </div>
+        <span class="text-white/30 group-hover:text-white/60 transition-colors text-sm">→</span>
+      </a>
+
       <div class="flex gap-2 mb-6">
         <button id="tab-home"
           class="admin-tab active flex-1 py-3 rounded-2xl text-sm font-bold tracking-wide transition-all duration-200">


### PR DESCRIPTION
## Summary
- 관리자가 사용자 퀴즈 신고를 조회하고 관리할 수 있는 기능 구현

## Changes
- 관리자 문제 신고 관리 페이지 추가
- 신고 목록 조회 및 처리 기능 구현

## Test plan
- [ ] 관리자 로그인 후 신고 관리 메뉴 진입 확인
- [ ] 신고 목록 조회 및 처리(승인/거절) 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)