### PR TITLE
feat: 퀴즈 문제 이상 신고(quiz report) 기능 구현

### DIFF
--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/config/SecurityConfig.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
                 .cors(cors -> {})
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/quiz-content").hasAuthority("ROLE_ADMIN")
+                        .requestMatchers("/api/quiz/reports").permitAll()
                         .requestMatchers("/api/quiz-status/public").permitAll()
                         .requestMatchers("/api/quiz-status/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers("/api/quiz-sessions/**").hasAuthority("ROLE_ADMIN")

--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/controller/QuizReportController.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/controller/QuizReportController.java
@@ -1,0 +1,27 @@
+package JesusDeciples.RankingQuiz.api.controller;
+
+import JesusDeciples.RankingQuiz.api.dto.QuizReportDto;
+import JesusDeciples.RankingQuiz.api.service.quizReport.QuizReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/quiz")
+@CrossOrigin(origins = {"http://localhost:8081", "https://rankingquiz.rivercastleworks.site"})
+@Tag(name = "QuizReport API", description = "퀴즈 문제 이상 신고 API 입니다.")
+public class QuizReportController {
+
+    private final QuizReportService quizReportService;
+
+    @PostMapping("/reports")
+    @Operation(summary = "문제 이상 신고 접수",
+            description = "사용자가 퀴즈 문제의 이상을 신고합니다. 퀴즈 ID, 카테고리, 문제 내용이 DB에 저장됩니다.")
+    public ResponseEntity<Void> reportQuizIssue(@RequestBody QuizReportDto dto) {
+        quizReportService.save(dto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/quizReport/QuizReportService.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/quizReport/QuizReportService.java
@@ -1,0 +1,7 @@
+package JesusDeciples.RankingQuiz.api.service.quizReport;
+
+import JesusDeciples.RankingQuiz.api.dto.QuizReportDto;
+
+public interface QuizReportService {
+    void save(QuizReportDto dto);
+}

--- a/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/quizReport/QuizReportServiceImpl.java
+++ b/RankingQuiz/app/src/main/java/JesusDeciples/RankingQuiz/api/service/quizReport/QuizReportServiceImpl.java
@@ -1,0 +1,19 @@
+package JesusDeciples.RankingQuiz.api.service.quizReport;
+
+import JesusDeciples.RankingQuiz.api.dto.QuizReportDto;
+import JesusDeciples.RankingQuiz.api.entity.QuizReport;
+import JesusDeciples.RankingQuiz.api.repository.QuizReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QuizReportServiceImpl implements QuizReportService {
+
+    private final QuizReportRepository quizReportRepository;
+
+    @Override
+    public void save(QuizReportDto dto) {
+        quizReportRepository.save(QuizReport.from(dto));
+    }
+}

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/QuizReportDto.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/dto/QuizReportDto.java
@@ -1,0 +1,16 @@
+package JesusDeciples.RankingQuiz.api.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class QuizReportDto {
+    private Long quizId;
+    private String category;
+    private String question;
+    private String answer;
+    private String myAnswer;
+    private String reporterId;
+    private LocalDateTime reportedAt;
+}

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/entity/QuizReport.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/entity/QuizReport.java
@@ -1,0 +1,58 @@
+package JesusDeciples.RankingQuiz.api.entity;
+
+import JesusDeciples.RankingQuiz.api.dto.QuizReportDto;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class QuizReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long quizId;
+
+    private String category;
+
+    @Column(length = 1000)
+    private String question;
+
+    @Column(length = 500)
+    private String answer;
+
+    @Column(length = 500)
+    private String myAnswer;
+
+    private String reporterId;
+
+    @Enumerated(EnumType.STRING)
+    private QuizReportStatus status;
+
+    private LocalDateTime reportedAt;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    private void prePersist() {
+        this.status = QuizReportStatus.UNREAD;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public static QuizReport from(QuizReportDto dto) {
+        QuizReport report = new QuizReport();
+        report.quizId     = dto.getQuizId();
+        report.category   = dto.getCategory();
+        report.question   = dto.getQuestion();
+        report.answer     = dto.getAnswer();
+        report.myAnswer   = dto.getMyAnswer();
+        report.reporterId = dto.getReporterId();
+        report.reportedAt = dto.getReportedAt();
+        return report;
+    }
+}

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/entity/QuizReportStatus.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/entity/QuizReportStatus.java
@@ -1,0 +1,5 @@
+package JesusDeciples.RankingQuiz.api.entity;
+
+public enum QuizReportStatus {
+    UNREAD, RESOLVED
+}

--- a/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/repository/QuizReportRepository.java
+++ b/RankingQuiz/core/src/main/java/JesusDeciples/RankingQuiz/api/repository/QuizReportRepository.java
@@ -1,0 +1,9 @@
+package JesusDeciples.RankingQuiz.api.repository;
+
+import JesusDeciples.RankingQuiz.api.entity.QuizReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuizReportRepository extends JpaRepository<QuizReport, Long> {
+}

--- a/RankingQuizFront/src/main/resources/static/js/quiz/quiz-report-func.js
+++ b/RankingQuizFront/src/main/resources/static/js/quiz/quiz-report-func.js
@@ -6,22 +6,40 @@ let _reportData = {
     myAnswer: null
 };
 
-function setReportData(quizId, category, question, answer, myAnswer) {
-    _reportData = { quizId, category, question, answer, myAnswer };
+function enableReportBtn(category, quizResultObject) {
+    _reportData = {
+        quizId:   Number(document.getElementById('quizId').textContent) || null,
+        category: category,
+        question: quizResultObject.statement,
+        answer:   quizResultObject.answer,
+        myAnswer: quizResultObject.myAnswer ?? null
+    };
 
     const btn = document.getElementById('reportBtn');
-    if (btn) {
-        btn.disabled = false;
-        btn.classList.remove('opacity-40', 'cursor-not-allowed');
-        btn.textContent = '';
-        btn.innerHTML =
-            '<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
-            '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" ' +
-            'd="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4' +
-            'c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>' +
-            '</svg>' +
-            '문제 이상 신고';
-    }
+    if (!btn) return;
+    btn.disabled = false;
+    btn.classList.remove('opacity-40', 'cursor-not-allowed');
+    btn.innerHTML =
+        '<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+        '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" ' +
+        'd="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4' +
+        'c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>' +
+        '</svg>' +
+        '문제 이상 신고';
+}
+
+function disableReportBtn() {
+    const btn = document.getElementById('reportBtn');
+    if (!btn) return;
+    btn.disabled = true;
+    btn.classList.add('opacity-40', 'cursor-not-allowed');
+    btn.innerHTML =
+        '<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+        '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" ' +
+        'd="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4' +
+        'c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>' +
+        '</svg>' +
+        '문제 이상 신고';
 }
 
 function reportQuizIssue() {

--- a/RankingQuizFront/src/main/resources/static/js/quiz/quiz-report-func.js
+++ b/RankingQuizFront/src/main/resources/static/js/quiz/quiz-report-func.js
@@ -1,0 +1,60 @@
+let _reportData = {
+    quizId:   null,
+    category: null,
+    question: null,
+    answer:   null,
+    myAnswer: null
+};
+
+function setReportData(quizId, category, question, answer, myAnswer) {
+    _reportData = { quizId, category, question, answer, myAnswer };
+
+    const btn = document.getElementById('reportBtn');
+    if (btn) {
+        btn.disabled = false;
+        btn.classList.remove('opacity-40', 'cursor-not-allowed');
+        btn.textContent = '';
+        btn.innerHTML =
+            '<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+            '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" ' +
+            'd="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4' +
+            'c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>' +
+            '</svg>' +
+            '문제 이상 신고';
+    }
+}
+
+function reportQuizIssue() {
+    const btn = document.getElementById('reportBtn');
+    if (!btn || btn.disabled) return;
+
+    const reporterId = sessionStorage.getItem('username') || 'anonymous';
+    const payload = {
+        quizId:     _reportData.quizId,
+        category:   _reportData.category,
+        question:   _reportData.question,
+        answer:     _reportData.answer,
+        myAnswer:   _reportData.myAnswer,
+        reporterId: reporterId,
+        reportedAt: new Date().toISOString().slice(0, 19)
+    };
+
+    fetch(protocol + BACKEND_BASE_URL + '/quiz/reports', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify(payload)
+    })
+    .then(res => {
+        if (res.ok) {
+            btn.disabled = true;
+            btn.classList.add('opacity-40', 'cursor-not-allowed');
+            btn.innerHTML =
+                '<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+                '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" ' +
+                'd="M5 13l4 4L19 7"/>' +
+                '</svg>' +
+                '신고 완료';
+        }
+    })
+    .catch(err => console.error('신고 전송 오류:', err));
+}

--- a/RankingQuizFront/src/main/resources/static/js/quiz/quiz-result-func.js
+++ b/RankingQuizFront/src/main/resources/static/js/quiz/quiz-result-func.js
@@ -1,4 +1,4 @@
-function quizResultUpdate(quizResultObject) {
+function quizResultUpdate(quizResultObject, category) {
     const isCorrectEl   = document.getElementById('isCorrect');
     const statementEl   = document.getElementById('statement');
     const quizAnswerEl  = document.getElementById('quizAnswer');
@@ -24,6 +24,15 @@ function quizResultUpdate(quizResultObject) {
             winnerNameEl.textContent = '정답자가 없습니다';
         }
     }
+
+    const quizId = Number(document.getElementById('quizId').textContent) || null;
+    setReportData(
+        quizId,
+        category || null,
+        quizResultObject.statement,
+        quizResultObject.answer,
+        quizResultObject.myAnswer ?? null
+    );
 }
 
 function quizResultOn() {

--- a/RankingQuizFront/src/main/resources/static/js/quiz/quiz-result-func.js
+++ b/RankingQuizFront/src/main/resources/static/js/quiz/quiz-result-func.js
@@ -1,4 +1,4 @@
-function quizResultUpdate(quizResultObject, category) {
+function quizResultUpdate(quizResultObject) {
     const isCorrectEl   = document.getElementById('isCorrect');
     const statementEl   = document.getElementById('statement');
     const quizAnswerEl  = document.getElementById('quizAnswer');
@@ -24,15 +24,6 @@ function quizResultUpdate(quizResultObject, category) {
             winnerNameEl.textContent = '정답자가 없습니다';
         }
     }
-
-    const quizId = Number(document.getElementById('quizId').textContent) || null;
-    setReportData(
-        quizId,
-        category || null,
-        quizResultObject.statement,
-        quizResultObject.answer,
-        quizResultObject.myAnswer ?? null
-    );
 }
 
 function quizResultOn() {

--- a/RankingQuizFront/src/main/resources/static/js/quiz/websocket-connect.js
+++ b/RankingQuizFront/src/main/resources/static/js/quiz/websocket-connect.js
@@ -54,6 +54,7 @@ function initQuizWebSocket(wsPath) {
         switch (data.dataType) {
             case 'QuizDto':
                 quizResultOff();
+                disableReportBtn();
                 guideMessageOff();
                 quizItemUpdate(data.object, socket);
                 break;
@@ -61,8 +62,9 @@ function initQuizWebSocket(wsPath) {
             case 'QuizResultDto':
                 guideMessageOff();
                 quizBoxOff();
-                quizResultUpdate(data.object, wsPath);
+                quizResultUpdate(data.object);
                 quizResultOn();
+                enableReportBtn(wsPath, data.object);
                 break;
 
             case 'GuideMessage':

--- a/RankingQuizFront/src/main/resources/static/js/quiz/websocket-connect.js
+++ b/RankingQuizFront/src/main/resources/static/js/quiz/websocket-connect.js
@@ -61,7 +61,7 @@ function initQuizWebSocket(wsPath) {
             case 'QuizResultDto':
                 guideMessageOff();
                 quizBoxOff();
-                quizResultUpdate(data.object);
+                quizResultUpdate(data.object, wsPath);
                 quizResultOn();
                 break;
 

--- a/RankingQuizFront/src/main/resources/templates/quiz/bible/bible.html
+++ b/RankingQuizFront/src/main/resources/templates/quiz/bible/bible.html
@@ -72,6 +72,13 @@
           <p id="statement" class="text-white/60 text-sm leading-relaxed"></p>
           <p id="quizAnswer" class="text-neon-purple font-bold text-base"></p>
           <p id="myAnswer" class="text-white/50 text-sm"></p>
+
+          <button id="reportBtn" class="flex items-center gap-1 text-xs text-red-500 hover:text-red-400 mt-2 transition-colors opacity-40 cursor-not-allowed" disabled onclick="reportQuizIssue()">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+            </svg>
+            문제 이상 신고
+          </button>
         </div>
 
         <div class="h-px bg-white/10"></div>
@@ -93,6 +100,7 @@
 
   <!-- Page-specific scripts (의존 순서 준수) -->
   <script th:src="@{/js/quiz/guide-message-func.js}"></script>
+  <script th:src="@{/js/quiz/quiz-report-func.js}"></script>
   <script th:src="@{/js/quiz/quiz-result-func.js}"></script>
   <script th:src="@{/js/quiz/item-control-func.js}"></script>
   <script th:src="@{/js/quiz/service-feedback-modal.js}"></script>

--- a/RankingQuizFront/src/main/resources/templates/quiz/voca/voca.html
+++ b/RankingQuizFront/src/main/resources/templates/quiz/voca/voca.html
@@ -72,6 +72,13 @@
           <p id="statement" class="text-white/60 text-sm leading-relaxed"></p>
           <p id="quizAnswer" class="text-neon-blue font-bold text-base"></p>
           <p id="myAnswer" class="text-white/50 text-sm"></p>
+
+          <button id="reportBtn" class="flex items-center gap-1 text-xs text-red-500 hover:text-red-400 mt-2 transition-colors opacity-40 cursor-not-allowed" disabled onclick="reportQuizIssue()">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+            </svg>
+            문제 이상 신고
+          </button>
         </div>
 
         <div class="h-px bg-white/10"></div>
@@ -93,6 +100,7 @@
 
   <!-- Page-specific scripts (의존 순서 준수) -->
   <script th:src="@{/js/quiz/guide-message-func.js}"></script>
+  <script th:src="@{/js/quiz/quiz-report-func.js}"></script>
   <script th:src="@{/js/quiz/quiz-result-func.js}"></script>
   <script th:src="@{/js/quiz/item-control-func.js}"></script>
   <script th:src="@{/js/quiz/service-feedback-modal.js}"></script>


### PR DESCRIPTION
## Summary
- 사용자가 퀴즈 진행 중 문제 이상을 신고할 수 있는 기능 구현

## Changes
- 퀴즈 문제 신고 기능 구현
- 신고 버튼 활성화/비활성화 로직을 websocket-connect.js로 이동

## Test plan
- [ ] 퀴즈 진행 중 신고 버튼 노출 확인
- [ ] 신고 제출 후 버튼 비활성화 확인
- [ ] 신고 데이터 서버 전달 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)